### PR TITLE
Short view tags

### DIFF
--- a/examples/counter/views/index.html
+++ b/examples/counter/views/index.html
@@ -16,6 +16,6 @@
 
 <body>
     <h1>${state.counter}</h1>
-    <button class="decrement" style:pointer:onClick="${this.decrement()}">-</button>
-    <button class="increment" style:pointer:onClick="${this.increment()}">+</button>
+    <button class="decrement" n-style:pointer:onClick="${this.decrement()}">-</button>
+    <button class="increment" n-style:pointer:onClick="${this.increment()}">+</button>
 </body>

--- a/src/document/attrChange.coffee
+++ b/src/document/attrChange.coffee
@@ -54,7 +54,7 @@ module.exports = (File) -> class AttrChange
 
     onAttrsChange = (name, oldValue) ->
         if name is 'name'
-            throw new Error "Dynamic neft:attr name is not implemented"
+            throw new Error 'Dynamic attr name is not implemented'
         else if name is 'value'
             @update()
         return

--- a/src/document/condition.coffee
+++ b/src/document/condition.coffee
@@ -22,7 +22,7 @@ module.exports = (File) -> class Condition
         obj
 
     onAttrsChange = (name) ->
-        if name is 'neft:if'
+        if name is 'n-if'
             @update()
         return
 
@@ -40,7 +40,7 @@ module.exports = (File) -> class Condition
         `//</development>`
 
     update: ->
-        visible = @node.visible = !!@node.attrs['neft:if']
+        visible = @node.visible = !!@node.attrs['n-if']
         @elseNode?.visible = not visible
         return
 

--- a/src/document/element/blank.md
+++ b/src/document/element/blank.md
@@ -1,6 +1,6 @@
-neft:blank @xml
-===============
+blank @xml
+==========
 
 ```xml
-<neft:blank neft:if="..."></neft:blank>
+<blank n-if="..."></blank>
 ```

--- a/src/document/element/element/parser.coffee
+++ b/src/document/element/element/parser.coffee
@@ -12,9 +12,6 @@ attrsValueGen = (i, elem) -> i
 module.exports = (Element) ->
     extensions = Element.Tag.extensions
 
-    internalTagsObject = utils.arrayToObject Element.Tag.INTERNAL_TAGS,
-        ((_, key) -> key), (-> true), Object.create(null)
-
     class Parser
         constructor: (callback) ->
             @_callback = callback
@@ -47,12 +44,6 @@ module.exports = (Element) ->
             return
 
         onopentag: (name, attribs) ->
-            null;
-            `//<development>`
-            if /^neft:/.test(name) and not internalTagsObject[name]
-                log.warn "Unknown internal tag name '#{name}'"
-            `//</development>`
-
             element = new (extensions[name] or Element.Tag)
             element.name = name
             utils.merge element.attrs, attribs
@@ -93,12 +84,14 @@ module.exports = (Element) ->
             r = node
 
         parser = new htmlparser.Parser handler,
-            xmlMode: false
+            xmlMode: true
             recognizeSelfClosing: true
             lowerCaseAttributeNames: false
             lowerCaseTags: false
             recognizeCDATA: true
             decodeEntities: true
+
+        parser._tokenizer._xmlMode = false # enable script and style
 
         # TODO: do it while parsing
         parser.onattribname = do (_super = parser.onattribname) -> (name) ->

--- a/src/document/element/element/tag.litcoffee
+++ b/src/document/element/element/tag.litcoffee
@@ -19,12 +19,6 @@
 # **Class** Tag : *Element*
 
     module.exports = (Element) -> class Tag extends Element
-        @INTERNAL_TAGS = [
-            'neft:attr', 'neft:fragment', 'neft:rule', 'neft:target',
-            'neft:use', 'neft:require', 'neft:blank', 'neft:log', 'neft:script',
-            'neft:style'
-        ]
-
         @DEFAULT_STRINGIFY_REPLACEMENTS = Object.create null
 
         @extensions = Object.create null
@@ -59,7 +53,7 @@
         constructor: ->
             Element.call this
 
-            @name = 'neft:blank'
+            @name = 'blank'
             @children = []
             @attrs = new Attrs @
 

--- a/src/document/element/element/tag/query.coffee
+++ b/src/document/element/element/tag/query.coffee
@@ -30,7 +30,7 @@ test = (node, funcs, index, targetFunc, targetCtx, single) ->
 
 anyDescendant = (node, funcs, index, targetFunc, targetCtx, single) ->
     for child in node.children
-        if not (child instanceof Tag) or child.name isnt 'neft:blank'
+        if not (child instanceof Tag) or child.name isnt 'blank'
             if test(child, funcs, index, targetFunc, targetCtx, single)
                 if single
                     return true
@@ -48,7 +48,7 @@ directParent = (node, funcs, index, targetFunc, targetCtx, single) ->
     if parent = node._parent
         if test(parent, funcs, index, targetFunc, targetCtx, single)
             return true
-        if parent.name is 'neft:blank'
+        if parent.name is 'blank'
             return directParent parent, funcs, index, targetFunc, targetCtx, single
     false
 directParent.isIterator = true
@@ -57,7 +57,7 @@ directParent.toString = -> 'directParent'
 
 anyChild = (node, funcs, index, targetFunc, targetCtx, single) ->
     for child in node.children
-        if child instanceof Tag and child.name is 'neft:blank'
+        if child instanceof Tag and child.name is 'blank'
             if anyChild(child, funcs, index, targetFunc, targetCtx, single)
                 if single
                     return true

--- a/src/document/element/element/tag/stringify.coffee
+++ b/src/document/element/element/tag/stringify.coffee
@@ -23,20 +23,20 @@ SINGLE_TAG =
     wbr: true
 
 isPublic = (name) ->
-    not /^(?:neft:|style:)/.test name
+    name isnt 'blank' and not /^(?:n-|style:)/.test(name)
 
 getInnerHTML = (elem, replacements) ->
     if elem.children
-        r = ""
+        r = ''
         for child in elem.children
             r += getOuterHTML child, replacements
         r
     else
-        ""
+        ''
 
 getOuterHTML = (elem, replacements) ->
     if elem._visible is false
-        return ""
+        return ''
 
     if elem._text isnt undefined
         return elem._text
@@ -44,12 +44,11 @@ getOuterHTML = (elem, replacements) ->
     if replacements and replacer = replacements[elem.name]
         elem = replacer(elem) or elem
 
-    name = elem.name
-
+    {name} = elem
     if not name or not isPublic(name)
         return getInnerHTML elem, replacements
 
-    ret = "<" + name
+    ret = '<' + name
     {attrs} = elem
     for attrName, attrValue of attrs
         if not attrs.hasOwnProperty(attrName)
@@ -57,13 +56,13 @@ getOuterHTML = (elem, replacements) ->
         if not attrValue? or typeof attrValue is 'function' or not isPublic(attrName)
             continue
 
-        ret += " " + attrName + "=\"" + attrValue + "\""
+        ret += ' ' + attrName + '="' + attrValue + '"'
 
     innerHTML = getInnerHTML elem, replacements
     if not innerHTML and SINGLE_TAG[name]
-        ret + " />"
+        ret + ' />'
     else
-        ret + ">" + innerHTML + "</" + name + ">"
+        ret + '>' + innerHTML + '</' + name + '>'
 
 module.exports =
     getInnerHTML: getInnerHTML

--- a/src/document/file/parse/attrChanges.litcoffee
+++ b/src/document/file/parse/attrChanges.litcoffee
@@ -1,10 +1,10 @@
-# neft:attr
+# attr
 
 Tag used to dynamically change an attribute of the parent element.
 
 ```xml
 <header id="header">
-    <neft:attr name="isActive" value="true" neft:if="${root.isActive}" />
+    <attr name="isActive" value="true" n-if="${root.isActive}" />
     <span>Active: ${ids.header.attrs.isActive}</span>
 </header>
 ```
@@ -17,7 +17,7 @@ Tag used to dynamically change an attribute of the parent element.
         (file) ->
             {attrChanges} = file
 
-            nodes = file.node.queryAll "neft:attr"
+            nodes = file.node.queryAll 'attr'
 
             for node in nodes
                 target = node.parent
@@ -32,4 +32,4 @@ Tag used to dynamically change an attribute of the parent element.
 
 # Glossary
 
-- [neft:attr](#neftattr)
+- [attr](#attr)

--- a/src/document/file/parse/attrs.litcoffee
+++ b/src/document/file/parse/attrs.litcoffee
@@ -4,7 +4,7 @@ Some of the attributes are automatically evaluated to the JavaScript objects.
 
 String `[...]` evaluates to an array.
 ```xml
-<use:list neft:each="[1, 2]" />
+<use:list n-each="[1, 2]" />
 ```
 ```xml
 <use:list items="[{name: 't-shirt'}]" />
@@ -22,7 +22,7 @@ String `Dict(...` evaluates to *Dict*.
 
 String `List(...` evaluates to *List*.
 ```xml
-<use:list neft:each="List([1, 2])" />
+<use:list n-each="List([1, 2])" />
 ```
 
     'use strict'

--- a/src/document/file/parse/conditions.litcoffee
+++ b/src/document/file/parse/conditions.litcoffee
@@ -1,10 +1,10 @@
-# neft:if
+# n-if
 
 Attribute used to hide or show the tag depends on the condition result.
 
 ```xml
-<span neft:if="${props.user.isLogged}">Hi ${props.user.name}!</span>
-<span neft:else>You need to log in</span>
+<span n-if="${props.user.isLogged}">Hi ${props.user.name}!</span>
+<span n-else>You need to log in</span>
 ```
 
     'use strict'
@@ -22,9 +22,9 @@ Attribute used to hide or show the tag depends on the condition result.
 
                     forEachNodeRec child
 
-                    if child.attrs.has('neft:if')
+                    if child.attrs.has('n-if')
                         elseNode = null
-                        if child.nextSibling?.attrs.has?('neft:else')
+                        if child.nextSibling?.attrs?.has?('n-else')
                             elseNode = child.nextSibling
 
                         conditions.push new File.Condition file, child, elseNode
@@ -34,4 +34,4 @@ Attribute used to hide or show the tag depends on the condition result.
 
 # Glossary
 
-- [neft:if](#neftif)
+- [n-if](#nif)

--- a/src/document/file/parse/fragments.litcoffee
+++ b/src/document/file/parse/fragments.litcoffee
@@ -1,20 +1,20 @@
-# neft:fragment
+# fragment
 
 Tag used to create separated and repeatable parts of the document.
 
-Each neft:fragment has to define a `neft:name` unique in the file where it's defined.
+Each fragment has to define a `name` unique in the file where it's defined.
 
-neft:fragment can be rendered by the *neft:use* tag.
+fragment can be rendered by the *use* tag.
 
 ```xml
-<neft:fragment neft:name="product">
+<fragment name="product">
   <h2>${props.name}</h2>
   <span>Type: ${props.type}</span>
-</neft:fragment>
+</fragment>
 
 <section>
-  <use:product type="electronics" name="dryer" />
-  <use:product type="painting" name="Lucretia, Paolo Veronese" />
+  <product type="electronics" name="dryer" />
+  <product type="painting" name="Lucretia, Paolo Veronese" />
 </section>
 ```
 
@@ -51,15 +51,15 @@ neft:fragment can be rendered by the *neft:use* tag.
                 while ++i < n
                     child = children[i]
 
-                    if child.name isnt 'neft:fragment'
+                    if child.name isnt 'fragment'
                         forEachNodeRec child
                         continue
 
-                    unless name = child.attrs['neft:name']
+                    unless name = child.attrs['name']
                         continue
 
                     # remove node from file
-                    child.name = 'neft:blank'
+                    child.name = 'blank'
                     child.parent = null
                     i--; n--
 
@@ -84,4 +84,4 @@ neft:fragment can be rendered by the *neft:use* tag.
 
 # Glossary
 
-- [neft:fragment](#neftfragment)
+- [fragment](#fragment)

--- a/src/document/file/parse/fragments/links.litcoffee
+++ b/src/document/file/parse/fragments/links.litcoffee
@@ -1,11 +1,10 @@
-# neft:require
+# import
 
-Tag used to link *neft:fragment*s from a file and use them.
+Tag used to link *fragment*s from a file and use them.
 
 ```xml
-<neft:require href="./user_utils.html" />
-
-<use:avatar />
+<import href="./user_utils.html" />
+<avatar />
 ```
 
 ## Namespace
@@ -13,9 +12,8 @@ Tag used to link *neft:fragment*s from a file and use them.
 Optional argument `as` will link all fragments into the specified namespace.
 
 ```xml
-<neft:require href="./user_utils.html" as="user" />
-
-<use:user:avatar />
+<import href="./user_utils.html" as="user" />
+<user:avatar />
 ```
 
     'use strict'
@@ -33,7 +31,7 @@ Optional argument `as` will link all fragments into the specified namespace.
         while ++i < n
             node = children[i]
 
-            if node.name isnt "#{File.HTML_NS}:require"
+            if node.name isnt 'import'
                 continue
 
             href = node.attrs.href or node.attrs.src
@@ -61,4 +59,4 @@ Optional argument `as` will link all fragments into the specified namespace.
 
 # Glossary
 
-- [neft:require](#neftrequire)
+- [import](#import)

--- a/src/document/file/parse/ids.litcoffee
+++ b/src/document/file/parse/ids.litcoffee
@@ -1,7 +1,7 @@
 # id
 
 *Element.Tag* with the id attribute is saved in the local scope
-(file, *neft:fragment*, *neft:each* etc.)
+(file, *fragment*, *n-each* etc.)
 and it's available in the string interpolation.
 
 Id must be unique in the scope.

--- a/src/document/file/parse/iterators.litcoffee
+++ b/src/document/file/parse/iterators.litcoffee
@@ -1,25 +1,25 @@
-# neft:each
+# n-each
 
 Attribute used for repeating.
 
 Tag children will be duplicated for each
-element defined in the *neft:each* attribute.
+element defined in the *n-each* attribute.
 
 Supports arrays and *List* instances.
 
 ```xml
-<ul neft:each="[1, 2]">
+<ul n-each="[1, 2]">
   <li>ping</li>
 </ul>
 ```
 
 In the tag children you have access to the three special variables:
-- **each** - `neft:each` attribute,
+- **each** - `n-each` attribute,
 - **item** - current element,
 - **index** - current element index.
 
 ```xml
-<ul neft:each="List(['New York', 'Paris', 'Warsaw'])">
+<ul n-each="List(['New York', 'Paris', 'Warsaw'])">
   <li>Index: ${props.index}; Current: ${props.item}; Next: ${props.each[i+1]}</li>
 </ul>
 ```
@@ -37,7 +37,7 @@ Use *List* to bind changes made in the array.
         createdFragments = []
 
         forNode = (elem) ->
-            unless attrVal = elem.attrs["neft:each"]
+            unless attrVal = elem.attrs['n-each']
                 for child in elem.children
                     if child instanceof File.Element.Tag
                         forNode child
@@ -70,4 +70,4 @@ Use *List* to bind changes made in the array.
 
 # Glossary
 
-- [neft:each](#nefteach)
+- [n-each](#neach)

--- a/src/document/file/parse/logs.litcoffee
+++ b/src/document/file/parse/logs.litcoffee
@@ -1,7 +1,7 @@
-# neft:log
+# log
 
 ```xml
-<neft:log debugObject="${props.someObject}">${props.debugText}</neft:log>
+<log debugObject="${props.someObject}">${props.debugText}</log>
 ```
 
     'use strict'
@@ -9,11 +9,11 @@
     module.exports = (File) -> (file) ->
         {logs} = file
 
-        for node in file.node.queryAll('neft:log')
+        for node in file.node.queryAll('log')
             logs.push new File.Log file, node
 
         return
 
 # Glossary
 
-- [neft:log](#neftlog)
+- [log](#log)

--- a/src/document/file/parse/rules.litcoffee
+++ b/src/document/file/parse/rules.litcoffee
@@ -1,4 +1,4 @@
-# neft:rule
+# rule
 
 Tag used in the parsing process.
 Performs some actions on found elements in the parent element.
@@ -8,9 +8,9 @@ Performs some actions on found elements in the parent element.
 Adds attributes if not exists.
 
 ```xml
-<neft:rule query="input[type=string]">
+<rule query="input[type=string]">
   <attrs class="specialInput" />
-</neft:rule>
+</rule>
 ```
 
     'use strict'
@@ -18,7 +18,7 @@ Adds attributes if not exists.
     utils = require 'src/utils'
     log = require 'src/log'
 
-    log = log.scope 'Document', 'neft:rule'
+    log = log.scope 'Document', 'rule'
 
     commands =
         'attrs': (command, node) ->
@@ -43,7 +43,7 @@ Adds attributes if not exists.
 
     isMainFileRule = (node) ->
         while node = node.parent
-            if node.name isnt 'neft:blank' and node.name isnt 'neft:rule'
+            if node.name isnt 'blank' and node.name isnt 'rule'
                 return false
         true
 
@@ -57,14 +57,14 @@ Adds attributes if not exists.
             fileRules[file.path] = rules
 
             # get rules from this file
-            localRules = file.node.queryAll 'neft:rule'
+            localRules = file.node.queryAll 'rule'
             localRules.sort (a, b) ->
                 getNodeLength(b) - getNodeLength(a)
 
             for rule in localRules
                 query = rule.attrs.query
                 unless query
-                    log.error "neft:rule no 'query' attribute found"
+                    log.error "rule no 'query' attribute found"
                     continue
 
                 children = rule.children
@@ -72,7 +72,7 @@ Adds attributes if not exists.
                 n = children.length
                 while i < n
                     child = children[i]
-                    if child.name is 'neft:rule'
+                    if child.name is 'rule'
                         subquery = child.attrs['query']
                         if /^[A-Za-z]/.test(subquery)
                             subquery = query + ' ' + subquery
@@ -114,4 +114,4 @@ Adds attributes if not exists.
 
 # Glossary
 
-- [neft:rule](#neftrule)
+- [rule](#rule)

--- a/src/document/file/parse/scripts.litcoffee
+++ b/src/document/file/parse/scripts.litcoffee
@@ -1,4 +1,4 @@
-# neft:script
+# script
 
     'use strict'
 
@@ -21,10 +21,14 @@
         scripts = []
 
         for tag in file.node.queryAll('script')
-            if Object.keys(tag.attrs).length is 0
-                tag.name = 'neft:script'
+            omit = false
+            for attr of tag.attrs
+                if attr not in ['src', 'href', 'filename']
+                    omit = true
+                    break
+            if omit
+                continue
 
-        for tag in file.node.queryAll('neft:script')
             tag.parent = null
 
             {src} = tag.attrs
@@ -54,4 +58,4 @@
 
 # Glossary
 
-- [neft:script](#neftscript)
+- [script](#neftscript)

--- a/src/document/file/parse/styles.litcoffee
+++ b/src/document/file/parse/styles.litcoffee
@@ -1,4 +1,4 @@
-# neft:style
+# style
 
     'use strict'
 
@@ -21,14 +21,10 @@
         if file instanceof File.Iterator
             return
 
-        for tag in file.node.children
-            if tag.name is 'style' and Object.keys(tag.attrs).length is 0
-                tag.name = 'neft:style'
-
         styleTags = []
         stylePath = "styles:#{file.path}"
         for tag in file.node.children
-            if tag.name isnt 'neft:style'
+            if tag.name isnt 'style'
                 continue
 
             styleTags.push tag
@@ -54,7 +50,7 @@
                     style: itemPath
 
             # detect main item with no document.query
-            unless file.node.attrs['neft:style']
+            unless file.node.attrs['n-style']
                 mainHasDoc = false
                 mainId = styleFile.codes._main.link
                 for _, id of styleFile.queries
@@ -62,7 +58,7 @@
                         mainHasDoc = true
                         break
                 unless mainHasDoc
-                    file.node.attrs.set 'neft:style', stylePath
+                    file.node.attrs.set 'n-style', stylePath
 
         while styleTags.length > 0
             styleTags.pop().parent = null
@@ -74,4 +70,4 @@
 
 # Glossary
 
-- [neft:style](#neftstyle)
+- [style](#style)

--- a/src/document/file/parse/target.litcoffee
+++ b/src/document/file/parse/target.litcoffee
@@ -1,26 +1,26 @@
-# neft:target
+# target
 
-Tag used in *neft:fragment* to define,
-where *neft:use* body should be placed.
+Tag used in *fragment* to define,
+where *use* body should be placed.
 
 ```xml
-<neft:fragment neft:name="user">
+<fragment name="user">
   <name>${props.name}</name>
   <age>${props.age}</age>
-  <neft:target />
-</neft:fragment>
+  <target />
+</fragment>
 
 <use:user name="Max" age="19">
   <superPower>flying</superPower>
-</neft:use>
+</use>
 ```
 
     'use strict'
 
     module.exports = (File) -> (file) ->
-        file.targetNode = file.node.query("neft:target")
-        file.targetNode?.name = 'neft:blank'
+        if file.targetNode = file.node.query('target')
+            file.targetNode.name = 'blank'
 
 # Glossary
 
-- [neft:target](#nefttarget)
+- [target](#target)

--- a/src/document/file/parse/uses.litcoffee
+++ b/src/document/file/parse/uses.litcoffee
@@ -1,53 +1,53 @@
-# neft:use
+# use
 
-Tag used to place *neft:fragment*.
+Tag used to place *fragment*.
 
 ```xml
-<neft:fragment neft:name="user">
+<fragment name="user">
   This is a user
-</neft:fragment>
+</fragment>
 
-<neft:use neft:fragment="user" />
+<use fragment="user" />
 ```
 
-*neft:fragment* attribute can be changed in runtime.
+*fragment* attribute can be changed in runtime.
 
 ```xml
-<neft:fragment neft:name="h1">
+<fragment name="h1">
   <h1>H1 heading</h1>
-</neft:fragment>
+</fragment>
 
-<neft:use neft:fragment="h${data.level}" />
+<use fragment="h${data.level}" />
 ```
 
-Short version of *neft:use* is a tag prefixed by `use:`.
+Short version of *use* is a tag prefixed by `use:`.
 
 ```xml
-<neft:fragment neft:name="user">
+<fragment name="user">
   This is a user
-</neft:fragment>
+</fragment>
 
-<use:user />
+<user />
 ```
 
-*neft:use* attributes are available in *neft:fragment* scope.
+*use* attributes are available in *fragment* scope.
 
 ```xml
-<neft:fragment neft:name="h1">
+<fragment name="heading">
   <h1>H1: ${props.data}</h1>
-</neft:fragment>
+</fragment>
 
-<use:h1 data="Test heading" />
+<heading data="Test heading" />
 ```
 
-## neft:async
+## n-async
 
 Renders fragment on the first free animation frame.
 
 Use this attribute to render less important elements.
 
 ```xml
-<use:body neft:async />
+<body n-async />
 ```
 
     'use strict'
@@ -64,21 +64,21 @@ Use this attribute to render less important elements.
             node.children.forEach forNode
 
             # change short syntax to long formula
-            if /^use\:/.test(node.name)
-                fragment = node.name.slice 'use:'.length
-                node.name = 'neft:use'
-                node.attrs['neft:fragment'] = fragment
+            if file.fragments[node.name]
+                fragment = node.name
+                node.name = 'use'
+                node.attrs['fragment'] = fragment
 
             # get uses
-            if node.name is 'neft:use'
-                node.name = 'neft:blank'
+            if node.name is 'use'
+                node.name = 'blank'
                 uses.push new File.Use file, node
 
         forNode file.node
 
-        unless utils.isEmpty uses
+        unless utils.isEmpty(uses)
             file.uses = uses
 
 # Glossary
 
-- [neft:use](#neftuse)
+- [use](#use)

--- a/src/document/index.litcoffee
+++ b/src/document/index.litcoffee
@@ -48,7 +48,6 @@
         JSON_STYLES = i++
         JSON_ARGS_LENGTH = @JSON_ARGS_LENGTH = i
 
-        @HTML_NS = 'neft'
         @FILES_PATH = ''
 
         signal.create @, 'onCreate'
@@ -59,25 +58,25 @@
 
 ## *Signal* Document.onBeforeRender(*Document* file)
 
-Corresponding node handler: *neft:onBeforeRender=""*.
+Corresponding node handler: *n-onBeforeRender=""*.
 
         signal.create @, 'onBeforeRender'
 
 ## *Signal* Document.onRender(*Document* file)
 
-Corresponding node handler: *neft:onRender=""*.
+Corresponding node handler: *n-onRender=""*.
 
         signal.create @, 'onRender'
 
 ## *Signal* Document.onBeforeRevert(*Document* file)
 
-Corresponding node handler: *neft:onBeforeRevert=""*.
+Corresponding node handler: *n-onBeforeRevert=""*.
 
         signal.create @, 'onBeforeRevert'
 
 ## *Signal* Document.onRevert(*Document* file)
 
-Corresponding node handler: *neft:onRevert=""*.
+Corresponding node handler: *n-onRevert=""*.
 
         signal.create @, 'onRevert'
 
@@ -414,7 +413,7 @@ Corresponding node handler: *neft:onRevert=""*.
                             inputProps.set prop, val
 
                 Document.onBeforeRender.emit @
-                emitNodeSignal @, 'neft:onBeforeRender'
+                emitNodeSignal @, 'n-onBeforeRender'
                 if @context?.node is @node
                     @context.state = @inputState
                     emitSignal @context, 'onBeforeRender'
@@ -447,7 +446,7 @@ Corresponding node handler: *neft:onRevert=""*.
 
                 @isRendered = true
                 Document.onRender.emit @
-                emitNodeSignal @, 'neft:onRender'
+                emitNodeSignal @, 'n-onRender'
                 if @context?.node is @node
                     emitSignal @context, 'onRender'
 
@@ -462,7 +461,7 @@ Corresponding node handler: *neft:onRevert=""*.
 
                 @isRendered = false
                 Document.onBeforeRevert.emit @
-                emitNodeSignal @, 'neft:onBeforeRevert'
+                emitNodeSignal @, 'n-onBeforeRevert'
                 if @context?.node is @node
                     emitSignal @context, 'onBeforeRevert'
 
@@ -500,7 +499,7 @@ Corresponding node handler: *neft:onRevert=""*.
                 @inputState.clear()
 
                 Document.onRevert.emit @
-                emitNodeSignal @, 'neft:onRevert'
+                emitNodeSignal @, 'n-onRevert'
                 if @context?.node is @node
                     @context.state = null
                     emitSignal @context, 'onRevert'
@@ -519,13 +518,13 @@ Corresponding node handler: *neft:onRevert=""*.
             if elem
                 elem.render view
             else
-                log.warn "'#{@path}' view doesn't have '#{useName}' neft:use"
+                log.warn "'#{@path}' view doesn't have '#{useName}' use"
 
             @
 
 ## *Signal* Document::onReplaceByUse(*Document.Use* use)
 
-Corresponding node handler: *neft:onReplaceByUse=""*.
+Corresponding node handler: *n-onReplaceByUse=""*.
 
         Emitter.createSignal @, 'onReplaceByUse'
 

--- a/src/document/iterator.coffee
+++ b/src/document/iterator.coffee
@@ -14,8 +14,6 @@ module.exports = (File) -> class Iterator
     @__name__ = 'Iterator'
     @__path__ = 'File.Iterator'
 
-    @HTML_ATTR = "#{File.HTML_NS}:each"
-
     JSON_CTOR_ID = @JSON_CTOR_ID = File.JSON_CTORS.push(Iterator) - 1
 
     i = 1
@@ -32,7 +30,7 @@ module.exports = (File) -> class Iterator
         obj
 
     attrsChangeListener = (name) ->
-        if @file.isRendered and name is 'neft:each'
+        if @file.isRendered and name is 'n-each'
             @update()
 
     visibilityChangeListener = (oldVal) ->
@@ -62,7 +60,7 @@ module.exports = (File) -> class Iterator
         unless @node.visible
             return
 
-        each = @node.attrs[Iterator.HTML_ATTR]
+        each = @node.attrs['n-each']
 
         # stop if nothing changed
         if each is @data
@@ -157,7 +155,7 @@ module.exports = (File) -> class Iterator
 
         # signal
         usedFragment.onReplaceByUse.emit @
-        File.emitNodeSignal usedFragment, 'neft:onReplaceByUse', @
+        File.emitNodeSignal usedFragment, 'n-onReplaceByUse', @
 
         @
 

--- a/src/document/use.coffee
+++ b/src/document/use.coffee
@@ -28,8 +28,8 @@ module.exports = (File) -> class Use
             @render()
 
     attrsChangeListener = (name) ->
-        if name is 'neft:fragment'
-            @name = @node.attrs['neft:fragment']
+        if name is 'fragment'
+            @name = @node.attrs['fragment']
 
             if @isRendered
                 @revert()
@@ -56,7 +56,7 @@ module.exports = (File) -> class Use
         assert.instanceOf @file, File
         assert.instanceOf @node, File.Element
 
-        @name = @node.attrs['neft:fragment']
+        @name = @node.attrs['fragment']
         @usedFragment = null
         @isRendered = false
 
@@ -73,7 +73,7 @@ module.exports = (File) -> class Use
     logUsesWithNoFragments = ->
         while useElem = usesWithNotFoundFragments.pop()
             unless useElem.usedFragment
-                log.warn "neft:fragment '#{useElem.name}' can't be find in file '#{useElem.file.path}'"
+                log.warn "fragment '#{useElem.name}' can't be find in file '#{useElem.file.path}'"
         return
     `//</development>`
 
@@ -88,10 +88,10 @@ module.exports = (File) -> class Use
         @isRendered = true
 
         useAsync = utils.isClient
-        useAsync &&= @node.attrs.has 'neft:async'
-        useAsync &&= @node.attrs['neft:async'] isnt false
+        useAsync &&= @node.attrs.has 'n-async'
+        useAsync &&= @node.attrs['n-async'] isnt false
         if useAsync
-            queue.push this, file
+            queue.push @, file
             unless queuePending
                 requestAnimationFrame runQueue
                 queuePending = true
@@ -126,7 +126,7 @@ module.exports = (File) -> class Use
         # signal
         usedFragment.parentUse = @
         usedFragment.onReplaceByUse.emit @
-        File.emitNodeSignal usedFragment, 'neft:onReplaceByUse', @
+        File.emitNodeSignal usedFragment, 'n-onReplaceByUse', @
 
         return
 

--- a/src/styles/style.coffee
+++ b/src/styles/style.coffee
@@ -39,8 +39,8 @@ module.exports = (File, data) -> class Style
                     log.warn 'document.query can be attached only to tags; ' +
                         "query '#{elem.query}' has been omitted for this node"
                     continue
-                unless node.attrs.has('neft:style')
-                    node.attrs.set 'neft:style', elem.style
+                unless node.attrs.has('n-style')
+                    node.attrs.set 'n-style', elem.style
 
         file
 
@@ -48,14 +48,14 @@ module.exports = (File, data) -> class Style
         getStyleAttrs = (node) ->
             attrs = null
             for attr of node.attrs when node.attrs.hasOwnProperty(attr)
-                if attr.slice(0, 6) is 'style:'
+                if attr.slice(0, 8) is 'n-style:'
                     attrs ?= {}
                     attrs[attr] = true
             attrs
 
         forNode = (file, node, parentStyle) ->
             isText = node instanceof Text
-            if isText or node.attrs['neft:style']
+            if isText or node.attrs['n-style']
                 style = new Style
                 style.file = file
                 style.node = node
@@ -152,7 +152,7 @@ module.exports = (File, data) -> class Style
         return
 
     setAttr: do ->
-        PREFIX_LENGTH = 'style:'.length
+        PREFIX_LENGTH = 'n-style:'.length
 
         getSplitAttr = do ->
             cache = Object.create null
@@ -297,8 +297,8 @@ module.exports = (File, data) -> class Style
         return
 
     ###
-    Creates and initializes renderer item based on the node 'neft:style' attribute.
-    The style node 'neft:style' attribute may be:
+    Creates and initializes renderer item based on the node 'n-style' attribute.
+    The style node 'n-style' attribute may be:
         - a 'Renderer.Item' instance - item will be used as is,
         - a string in format:
             - 'renderer:Type' where the 'Type' is a Renderer class;
@@ -325,8 +325,8 @@ module.exports = (File, data) -> class Style
         {node} = @
 
         if node instanceof Tag
-            id = node.attrs['neft:style']
-            assert.isDefined id, "Tag must specify 'neft:style' attr to create an item for it"
+            id = node.attrs['n-style']
+            assert.isDefined id, "Tag must specify 'n-style' attr to create an item for it"
         else if node instanceof Text
             id = Renderer.Text.New()
 
@@ -344,7 +344,7 @@ module.exports = (File, data) -> class Style
                 parent = @parent
 
                 loop
-                    if parent and parent.node.attrs['neft:style'] is parentId
+                    if parent and parent.node.attrs['n-style'] is parentId
                         scope = parent.scope
                         @item = scope.objects[subid]
                     else if not parent?.scope and file in ['view', '__view__']
@@ -372,7 +372,7 @@ module.exports = (File, data) -> class Style
             @item = Renderer[type].New()
 
         else
-            throw new Error "Unexpected neft:style; '#{id}' given"
+            throw new Error "Unexpected n-style; '#{id}' given"
 
         if @item
             @isAutoParent = not @item.parent
@@ -521,7 +521,7 @@ module.exports = (File, data) -> class Style
         node._documentStyle = clone
 
         if node instanceof Tag
-            styleAttr = node.attrs['neft:style']
+            styleAttr = node.attrs['n-style']
             clone.isAutoParent = not /^styles:(.+?)\:(.+?)\:(.+?)$/.test(styleAttr)
 
         # set attrs

--- a/tests/init.coffee
+++ b/tests/init.coffee
@@ -1,4 +1,7 @@
 if process.argv.indexOf('--coverage') >= 0
     require 'coffee-coverage/register-istanbul'
+else
+    require('lib/moduleCache').registerFilenameResolver()
+    require('lib/moduleCache').registerCoffeeScript()
 global.Neft = require '../index'
 global.Neft.unit = require 'lib/unit'

--- a/tests/src/document/condition.coffee
+++ b/tests/src/document/condition.coffee
@@ -4,29 +4,29 @@
 {describe, it} = unit
 {createView, renderParse} = require './utils'
 
-describe 'src/document neft:if', ->
+describe 'src/document n-if', ->
     it 'works with positive expression', ->
-        source = createView '<div><b neft:if="${2 > 1}">1</b></div>'
+        source = createView '<div><b n-if="${2 > 1}">1</b></div>'
         view = source.clone()
 
         renderParse view
         assert.is view.node.stringify(), '<div><b>1</b></div>'
 
     it 'works with negative expression', ->
-        source = createView '<div><b neft:if="${1 > 2}">1</b></div>'
+        source = createView '<div><b n-if="${1 > 2}">1</b></div>'
         view = source.clone()
 
         renderParse view
         assert.is view.node.stringify(), '<div></div>'
 
     it 'supports runtime updates', ->
-        source = createView """
-            <neft:fragment neft:name="a">
-                <b neft:if="${props.x > 1}">OK</b>
-                <b neft:if="${props.x === 1}">FAIL</b>
-            </neft:fragment>
-            <neft:use neft:fragment="a" x="1" />
-        """
+        source = createView '''
+            <fragment name="a">
+                <b n-if="${props.x > 1}">OK</b>
+                <b n-if="${props.x === 1}">FAIL</b>
+            </fragment>
+            <use fragment="a" x="1" />
+        '''
         view = source.clone()
         elem = view.node.children[0]
 

--- a/tests/src/document/element/index.coffee
+++ b/tests/src/document/element/index.coffee
@@ -30,7 +30,7 @@ describe 'src/document Element', ->
             assert.is p.children.length, 0
 
         it 'has proper elements names', ->
-            assert.is doc.name, 'neft:blank'
+            assert.is doc.name, 'blank'
             assert.is b.name, 'b'
             assert.is em.name, 'em'
             assert.is div.name, 'u'
@@ -41,7 +41,7 @@ describe 'src/document Element', ->
         assert.is html, HTML
 
     it 'hidden attrs are omitted in the stringified process', ->
-        elem = Element.fromHTML '<span neft:if="a" neft:each="a"></span>'
+        elem = Element.fromHTML '<span n-if="a" n-each="a"></span>'
         html = elem.stringify()
 
         assert.is html, '<span></span>'
@@ -159,7 +159,7 @@ describe 'src/document Element', ->
         assert.is elem.stringify(), '<b><em></em></b><u></u><p></p>'
 
     describe 'queryAll() works with selector', ->
-        doc2 = Element.fromHTML "<div><b class='first second'><u color='blue' attr='1'>text1<u></u></u></b></div><div attr='2'><neft:blank><em>text2</em></neft:blank><em></em></div>"
+        doc2 = Element.fromHTML "<div><b class='first second'><u color='blue' attr='1'>text1<u></u></u></b></div><div attr='2'><blank><em>text2</em></blank><em></em></div>"
         doc2div1 = doc2.children[0]
         doc2b = doc2div1.children[0]
         doc2u = doc2b.children[0]
@@ -241,11 +241,11 @@ describe 'src/document Element', ->
         it 'E #text', ->
             assert.isEqual doc2.queryAll('em #text'), [doc2em1.children[0]], maxDeep: 1
 
-        it 'omits neft:blank', ->
+        it 'omits blank', ->
             assert.isEqual doc2.queryAll('div > em'), [doc2em1, doc2em2], maxDeep: 1
 
     describe 'query() works with selector', ->
-        doc2 = Element.fromHTML "<div><b><u color='blue' attr='1'></u></b></div><div attr='2'><neft:blank><em></em></neft:blank></div>"
+        doc2 = Element.fromHTML "<div><b><u color='blue' attr='1'></u></b></div><div attr='2'><blank><em></em></blank></div>"
         doc2div1 = doc2.children[0]
         doc2b = doc2div1.children[0]
         doc2u = doc2b.children[0]
@@ -261,11 +261,11 @@ describe 'src/document Element', ->
             assert.is doc2.query('[color]'), doc2u
             assert.is doc2.query('[width]'), null
 
-        it 'omits neft:blank', ->
+        it 'omits blank', ->
             assert.is doc2.query('div > em'), doc2em
 
     describe 'queryParents() works with selector', ->
-        doc2 = Element.fromHTML "<div><b><u color='blue' attr='1'></u></b></div><div attr='2'><neft:blank><em></em></neft:blank></div>"
+        doc2 = Element.fromHTML "<div><b><u color='blue' attr='1'></u></b></div><div attr='2'><blank><em></em></blank></div>"
         doc2div1 = doc2.children[0]
         doc2b = doc2div1.children[0]
         doc2u = doc2b.children[0]
@@ -291,7 +291,7 @@ describe 'src/document Element', ->
                 tags = []
                 doc2 = Element.fromHTML """
                     <div><b><u color='blue' attr='1'><u></u></u></b></div>
-                    <div attr='2'><neft:blank><em>text1</em></neft:blank><em></em></div>
+                    <div attr='2'><blank><em>text1</em></blank><em></em></div>
                     """
                 doc2div1 = doc2.children[0]
                 doc2b = doc2div1.children[0]

--- a/tests/src/document/file.coffee
+++ b/tests/src/document/file.coffee
@@ -14,11 +14,14 @@ describe 'src/document View', ->
         assert.is view.node.stringify(), '<div></div>'
 
     it 'finds fragments', ->
-        view = createView '<neft:fragment neft:name="a"></neft:fragment>'
+        view = createView '<fragment name="a"></fragment>'
         assert.is Object.keys(view.fragments).length, 1
 
     it 'finds uses', ->
-        view = createView '<neft:fragment neft:name="a"><b></b></neft:fragment><neft:use neft:fragment="a" />'
+        view = createView '''
+            <fragment name="a"><b></b></fragment>
+            <use fragment="a" />
+        '''
         assert.is view.uses.length, 1
 
     it 'can be cloned and destroyed', ->

--- a/tests/src/document/input.coffee
+++ b/tests/src/document/input.coffee
@@ -6,10 +6,10 @@
 
 describe 'src/document string interpolation', ->
     describe '`props`', ->
-        it 'lookup neft:fragment', ->
+        it 'lookup fragment', ->
             source = createView '''
-                <neft:fragment neft:name="a" x="2">${props.x}</neft:fragment>
-                <neft:use neft:fragment="a" />
+                <fragment name="a" x="2">${props.x}</fragment>
+                <use fragment="a" />
             '''
             view = source.clone()
 
@@ -18,20 +18,20 @@ describe 'src/document string interpolation', ->
 
         it 'is accessible by context', ->
             source = createView '''
-                <neft:fragment neft:name="a" x="2">
+                <fragment name="a" x="2">
                     ${this.props.x}
-                </neft:fragment>
-                <neft:use neft:fragment="a" />
+                </fragment>
+                <use fragment="a" />
             '''
             view = source.clone()
 
             renderParse view
             assert.is view.node.stringify(), '2'
 
-        it 'lookup neft:use', ->
+        it 'lookup use', ->
             source = createView '''
-                <neft:fragment neft:name="a" x="1">${props.x}</neft:fragment>
-                <neft:use neft:fragment="a" x="2" />
+                <fragment name="a" x="1">${props.x}</fragment>
+                <use fragment="a" x="2" />
             '''
             view = source.clone()
 
@@ -40,13 +40,13 @@ describe 'src/document string interpolation', ->
 
         it 'always keeps proper sources order', ->
             source = createView '''
-                <neft:fragment neft:name="a" x="1">
-                    <neft:fragment neft:name="b" x="1">
+                <fragment name="a" x="1">
+                    <fragment name="b" x="1">
                         ${props.x}
-                    </neft:fragment>
-                    <neft:use neft:fragment="b" x="4" />
-                </neft:fragment>
-                <neft:use neft:fragment="a" x="3" />
+                    </fragment>
+                    <use fragment="b" x="4" />
+                </fragment>
+                <use fragment="a" x="3" />
             '''
             view = source.clone()
 
@@ -112,10 +112,10 @@ describe 'src/document string interpolation', ->
     it 'file `ids` are accessed in fragments', ->
         source = createView '''
             <a id="first" label="12" visible="false" />
-            <neft:fragment neft:name="a">
+            <fragment name="a">
                 ${ids.first.attrs.label}
-            </neft:fragment>
-            <neft:use neft:fragment="a" />
+            </fragment>
+            <use fragment="a" />
         '''
         view = source.clone()
 
@@ -156,10 +156,10 @@ describe 'src/document string interpolation', ->
                 storage: a: '2'
             assert.is view.node.stringify(), '2'
 
-        it 'lookup neft:use', ->
+        it 'lookup use', ->
             source = createView '''
-                <neft:fragment neft:name="a">${root.a}</neft:fragment>
-                <neft:use neft:fragment="a" />
+                <fragment name="a">${root.a}</fragment>
+                <use fragment="a" />
             '''
             view = source.clone()
 
@@ -172,11 +172,11 @@ describe 'src/document string interpolation', ->
                 storage: a: '2'
             assert.is view.node.stringify(), '2'
 
-        it 'lookup neft:each', ->
+        it 'lookup n-each', ->
             source = createView '''
-                <neft:blank neft:each="[1]">
+                <blank n-each="[1]">
                     ${root.a}
-                </neft:blank>
+                </blank>
             '''
             view = source.clone()
 
@@ -286,7 +286,7 @@ describe 'src/document string interpolation', ->
 
     it 'attribute handler is called with proper context and parameters', ->
         source = createView '''
-            <neft:attr name="y" value="3" />
+            <attr name="y" value="3" />
             <span
               x="1"
               id="a1"
@@ -308,7 +308,7 @@ describe 'src/document string interpolation', ->
 
     it 'attribute handler is not called if the document is not rendered', ->
         source = createView '''
-            <neft:attr name="y" value="3" />
+            <attr name="y" value="3" />
             <span x="1" id="a1" onAttrsChange="${root.onAttrsChange()}" />
         '''
         view = source.clone()
@@ -329,8 +329,8 @@ describe 'src/document string interpolation', ->
     describe 'support realtime changes', ->
         it 'on `props`', ->
             source = createView '''
-                <neft:fragment neft:name="a">${props.x}</neft:fragment>
-                <neft:use neft:fragment="a" x="2" y="1" />
+                <fragment name="a">${props.x}</fragment>
+                <use fragment="a" x="2" y="1" />
             '''
             view = source.clone()
             elem = view.node.children[0]
@@ -365,10 +365,10 @@ describe 'src/document string interpolation', ->
             storage.dict.set 'x', 2
             assert.is view.node.stringify(), '2'
 
-        it 'on `root` neft:use', ->
+        it 'on `root` use', ->
             source = createView '''
-                <neft:fragment neft:name="a">${root.a}</neft:fragment>
-                <neft:use neft:fragment="a" />
+                <fragment name="a">${root.a}</fragment>
+                <use fragment="a" />
             '''
             view = source.clone()
 
@@ -378,11 +378,11 @@ describe 'src/document string interpolation', ->
             storage.set 'a', 2
             assert.is view.node.stringify(), '2'
 
-        it 'on `root` neft:each', ->
+        it 'on `root` n-each', ->
             source = createView '''
-                <neft:blank neft:each="[1]">
+                <blank n-each="[1]">
                     ${root.a}
-                </neft:blank>
+                </blank>
             '''
             view = source.clone()
 

--- a/tests/src/document/iterator.coffee
+++ b/tests/src/document/iterator.coffee
@@ -4,37 +4,37 @@
 {describe, it} = unit
 {createView, renderParse} = require './utils'
 
-describe 'src/document neft:each', ->
+describe 'src/document n-each', ->
     it 'loops expected times', ->
-        source = createView '<ul neft:each="[0,0]">1</ul>'
+        source = createView '<ul n-each="[0,0]">1</ul>'
         view = source.clone()
 
         renderParse view
         assert.is view.node.stringify(), '<ul>11</ul>'
 
     it 'provides `props.item` property', ->
-        source = createView '<ul neft:each="[1,2]">${props.item}</ul>'
+        source = createView '<ul n-each="[1,2]">${props.item}</ul>'
         view = source.clone()
 
         renderParse view
         assert.is view.node.stringify(), '<ul>12</ul>'
 
     it 'provides `props.index` property', ->
-        source = createView '<ul neft:each="[1,2]">${props.index}</ul>'
+        source = createView '<ul n-each="[1,2]">${props.index}</ul>'
         view = source.clone()
 
         renderParse view
         assert.is view.node.stringify(), '<ul>01</ul>'
 
     it 'provides `props.each` property', ->
-        source = createView '<ul neft:each="[1,2]">${props.each}</ul>'
+        source = createView '<ul n-each="[1,2]">${props.each}</ul>'
         view = source.clone()
 
         renderParse view
         assert.is view.node.stringify(), '<ul>1,21,2</ul>'
 
     it 'supports runtime updates', ->
-        source = createView '<ul neft:each="${props.arr}">${props.each[props.index]}</ul>'
+        source = createView '<ul n-each="${props.arr}">${props.each[props.index]}</ul>'
         view = source.clone()
 
         props = arr: arr = new List [1, 2]
@@ -52,7 +52,7 @@ describe 'src/document neft:each', ->
         assert.is view.node.stringify(), '<ul>123</ul>'
 
     it 'access global `props`', ->
-        source = createView '<ul neft:each="[1,2]">${props.a}</ul>'
+        source = createView '<ul n-each="[1,2]">${props.a}</ul>'
         view = source.clone()
 
         renderParse view,
@@ -60,7 +60,7 @@ describe 'src/document neft:each', ->
         assert.is view.node.stringify(), '<ul>aa</ul>'
 
     it 'access global `props` by context', ->
-        source = createView '<ul neft:each="[1,2]">${this.props.a}</ul>'
+        source = createView '<ul n-each="[1,2]">${this.props.a}</ul>'
         view = source.clone()
 
         renderParse view,
@@ -70,19 +70,19 @@ describe 'src/document neft:each', ->
     it 'access `ids`', ->
         source = createView """
             <div id="a" prop="a" visible="false" />
-            <ul neft:each="[1,2]">${ids.a.attrs.prop}</ul>
+            <ul n-each="[1,2]">${ids.a.attrs.prop}</ul>
         """
         view = source.clone()
 
         renderParse view
         assert.is view.node.stringify(), '<ul>aa</ul>'
 
-    it 'access neft:fragment `props`', ->
+    it 'access fragment `props`', ->
         source = createView """
-            <neft:fragment neft:name="a" a="a">
-                <ul neft:each="[1,2]">${props.a}${props.b}</ul>
-            </neft:fragment>
-            <neft:use neft:fragment="a" b="b" />
+            <fragment name="a" a="a">
+                <ul n-each="[1,2]">${props.a}${props.b}</ul>
+            </fragment>
+            <use fragment="a" b="b" />
         """
         view = source.clone()
 
@@ -91,18 +91,18 @@ describe 'src/document neft:each', ->
 
     it 'uses parent `this` context', ->
         source = createView """
-            <neft:fragment neft:name="a">
-                <neft:script>
+            <fragment name="a">
+                <script>
                     this.onCreate(function(){
                         this.self = this;
                     });
                     this.getX = function(){
                         return this === this.self ? 1 : 0;
                     };
-                </neft:script>
-                <ul neft:each="[1,2]">${this.getX()}</ul>
-            </neft:fragment>
-            <neft:use neft:fragment="a" />
+                </script>
+                <ul n-each="[1,2]">${this.getX()}</ul>
+            </fragment>
+            <use fragment="a" />
         """
         view = source.clone()
 
@@ -111,7 +111,7 @@ describe 'src/document neft:each', ->
 
     it 'internal props are not accessible by context', ->
         source = createView '''
-            <ul neft:each="[0]">
+            <ul n-each="[0]">
                 ${this.props.item}${this.props.index}${this.props.each}
             </ul>
         '''

--- a/tests/src/document/require.coffee
+++ b/tests/src/document/require.coffee
@@ -4,20 +4,20 @@
 {describe, it} = unit
 {createView, renderParse, uid} = require './utils'
 
-describe 'src/document neft:require', ->
+describe 'src/document import', ->
     describe 'shares fragments', ->
         it 'without namespace', ->
             first = "namespace#{uid()}"
-            view1 = createView '<neft:fragment neft:name="a"></neft:fragment>', first
-            view2 = createView '<neft:require href="' + first + '" />'
+            view1 = createView '<fragment name="a"></fragment>', first
+            view2 = createView '<import href="' + first + '" />'
 
             assert.is Object.keys(view2.fragments).length, 1
             assert.is Object.keys(view2.fragments)[0], 'a'
 
         it 'with namespace', ->
             first = uid()
-            view1 = createView '<neft:fragment neft:name="a"></neft:fragment>', first
-            view2 = createView '<neft:require href="' + first + '" as="ns">'
+            view1 = createView '<fragment name="a"></fragment>', first
+            view2 = createView '<import href="' + first + '" as="ns">'
 
             assert.is Object.keys(view2.fragments).length, 2
             assert.is Object.keys(view2.fragments)[0], 'ns'

--- a/tests/src/document/script.coffee
+++ b/tests/src/document/script.coffee
@@ -6,10 +6,10 @@ os = require 'os'
 {describe, it} = unit
 {createView, renderParse, uid} = require './utils'
 
-describe 'src/document neft:script', ->
+describe 'src/document script', ->
     it 'is not rendered', ->
         view = createView '''
-            <neft:script></neft:script>
+            <script></script>
         '''
         view = view.clone()
 
@@ -18,9 +18,9 @@ describe 'src/document neft:script', ->
 
     it 'context is shared between rendered views', ->
         view = createView '''
-            <neft:script><![CDATA[
+            <script>
                 this.a = Math.random();
-            ]]></neft:script>
+            </script>
         '''
         view = view.clone()
 
@@ -37,49 +37,28 @@ describe 'src/document neft:script', ->
         renderParse view2
         assert.is view2.context.__proto__, proto
 
-    describe '<script>', ->
-        it 'works like <neft:script>', ->
-            view = createView '''
-                <script>
-                    this.a = Math.random();
-                </script>
-            '''
-            view = view.clone()
+    it 'is disabled if contains unknown attributes', ->
+        view = createView '''
+            <script type="text">
+                this.a = Math.random();
+            </script>
+        '''
+        view = view.clone()
 
-            renderParse view
-            assert.isFloat view.context.a
-
-        it 'is not rendered', ->
-            view = createView '''
-                <script></script>
-            '''
-            view = view.clone()
-
-            renderParse view
-            assert.is view.node.stringify(), ''
-
-        it 'does not work if has attributes', ->
-            view = createView '''
-                <script src=""><![CDATA[
-                    this.a = 1;
-                ]]></script>
-            '''
-            view = view.clone()
-
-            renderParse view
-            assert.isNot view.node.stringify(), ''
-            assert.is view.context?.a, undefined
+        renderParse view
+        proto = view.context.__proto__
+        assert.is view.context.a, undefined
 
     describe 'this.onCreate()', ->
         it 'is called on a view clone', ->
             view = createView '''
-                <neft:attr name="x" value="1" />
-                <neft:script><![CDATA[
+                <attr name="x" value="1" />
+                <script>
                     this.onCreate(function(){
                         this.b = 2;
                     });
                     this.a = 1;
-                ]]></neft:script>
+                </script>
             '''
             view = view.clone()
 
@@ -100,13 +79,13 @@ describe 'src/document neft:script', ->
 
         it 'is called with its prototype', ->
             view = createView '''
-                <neft:script><![CDATA[
+                <script>
                     this.onCreate(function(){
                         this.proto = this;
                         this.protoA = this.a;
                     });
                     this.a = 1;
-                ]]></neft:script>
+                </script>
             '''
             view = view.clone()
 
@@ -116,12 +95,12 @@ describe 'src/document neft:script', ->
 
         it 'is called with props in context', ->
             view = createView '''
-                <neft:script><![CDATA[
+                <script>
                     this.onCreate(function(){
                         this.a = this.props.a;
                     });
-                ]]></neft:script>
-                <neft:attr name="a" value="1" />
+                </script>
+                <attr name="a" value="1" />
             '''
             view = view.clone()
 
@@ -130,11 +109,11 @@ describe 'src/document neft:script', ->
 
         it 'is called with ids in context', ->
             view = createView '''
-                <neft:script><![CDATA[
+                <script>
                     this.onCreate(function(){
                         this.a = this.ids.x.attrs.a;
                     });
-                ]]></neft:script>
+                </script>
                 <b id="x" a="1" />
             '''
             view = view.clone()
@@ -144,11 +123,11 @@ describe 'src/document neft:script', ->
 
         it 'is called with root in context', ->
             view = createView '''
-                <neft:script><![CDATA[
+                <script>
                     this.onRender(function(){
                         this.a = this.root.a;
                     });
-                ]]></neft:script>
+                </script>
             '''
             view = view.clone()
 
@@ -157,11 +136,11 @@ describe 'src/document neft:script', ->
 
         it 'is called with file node in context', ->
             view = createView '''
-                <neft:script><![CDATA[
+                <script>
                     this.onCreate(function(){
                         this.aNode = this.node;
                     });
-                ]]></neft:script>
+                </script>
             '''
             view = view.clone()
 
@@ -171,9 +150,9 @@ describe 'src/document neft:script', ->
     describe.onServer '[filename]', ->
         it 'supports .coffee files', ->
             view = Document.fromHTML uid(), '''
-                <neft:script filename="a.coffee"><![CDATA[
+                <script filename="a.coffee">
                     @a = 1
-                ]]></neft:script>
+                </script>
             '''
             Document.parse view
             view = view.clone()
@@ -183,7 +162,7 @@ describe 'src/document neft:script', ->
 
     it 'predefined context properties are not enumerable', ->
         view = createView '''
-            <neft:script><![CDATA[
+            <script>
                 var protoKeys = [];
                 for (var key in this) {
                     protoKeys.push(key);
@@ -196,7 +175,7 @@ describe 'src/document neft:script', ->
                         keys.push(key);
                     }
                 });
-            ]]></neft:script>
+            </script>
         '''
         view = view.clone()
 
@@ -205,19 +184,19 @@ describe 'src/document neft:script', ->
 
     it 'further tags are properly called', ->
         view = createView '''
-            <neft:script><![CDATA[
+            <script>
                 this.onCreate(function(){
                     this.aa = 1;
                 });
                 this.a = 1;
-            ]]></neft:script>
-            <neft:script><![CDATA[
+            </script>
+            <script>
                 this.onCreate(function(){
                     this.bb = 1;
                     this.bbaa = this.aa;
                 });
                 this.b = 1;
-            ]]></neft:script>
+            </script>
         '''
         view = view.clone()
 
@@ -231,27 +210,15 @@ describe 'src/document neft:script', ->
 
     it 'can contains XML text', ->
         source = createView """
-            <neft:script><![CDATA[
-                this.a = '<&&</neft:script>';
-            ]]></neft:script>
-            ${this.a}
-        """
-        view = source.clone()
-
-        renderParse view
-        assert.is view.node.stringify(), '<&&</neft:script>'
-
-    it '<script> can contains XML text with no CDATA', ->
-        source = createView """
             <script>
-                this.a = '<&&</neft:script>';
+                this.a = '<&&</b>';
             </script>
             ${this.a}
         """
         view = source.clone()
 
         renderParse view
-        assert.is view.node.stringify(), '<&&</neft:script>'
+        assert.is view.node.stringify(), '<&&</b>'
 
     it.onServer 'accepts `src` attribute', ->
         filename = "tmp#{uid()}.js"
@@ -260,8 +227,8 @@ describe 'src/document neft:script', ->
         fs.writeFileSync path, file, 'utf-8'
 
         source = Document.fromHTML uid(), """
-            <neft:script src="#{path}" />
-            <neft:blank>${this.a}</neft:blank>
+            <script src="#{path}"></script>
+            <blank>${this.a}</blank>
         """
         Document.parse source
         view = source.clone()
@@ -278,8 +245,8 @@ describe 'src/document neft:script', ->
         viewFilename = "tmp#{uid()}"
         viewPath = "#{os.tmpdir()}/#{viewFilename}"
         fs.writeFileSync viewPath, viewStr = """
-            <neft:script src="./#{scriptFilename}" />
-            <neft:blank>${this.a}</neft:blank>
+            <script src="./#{scriptFilename}"></script>
+            <blank>${this.a}</blank>
         """
 
         source = Document.fromHTML viewPath, viewStr
@@ -291,7 +258,7 @@ describe 'src/document neft:script', ->
 
     it 'properly calls events', ->
         view = createView """
-            <neft:script><![CDATA[
+            <script>
                 this.onCreate(function(){
                     this.events = [];
                 });
@@ -307,7 +274,7 @@ describe 'src/document neft:script', ->
                 this.onRevert(function(){
                     this.events.push('onRevert');
                 });
-            ]]></neft:script>
+            </script>
         """
         view = view.clone()
 
@@ -324,7 +291,7 @@ describe 'src/document neft:script', ->
 
     it 'does not call events for foreign context', ->
         view = createView """
-            <neft:script><![CDATA[
+            <script>
                 this.onCreate(function(){
                     this.events = [];
                 });
@@ -340,8 +307,8 @@ describe 'src/document neft:script', ->
                 this.onRevert(function(){
                     this.events.push('onRevert');
                 });
-            ]]></neft:script>
-            <ul neft:each="[1,2]">${props.item}</ul>
+            </script>
+            <ul n-each="[1,2]">${props.item}</ul>
         """
         view = view.clone()
 

--- a/tests/src/document/style.coffee
+++ b/tests/src/document/style.coffee
@@ -8,10 +8,10 @@ os = require 'os'
 
 styles {queries: []}
 
-describe 'src/document neft:style', ->
+describe 'src/document style', ->
     it 'is not rendered', ->
         view = createView '''
-            <neft:style></neft:style>
+            <style></style>
         '''
         view = view.clone()
 
@@ -20,89 +20,54 @@ describe 'src/document neft:style', ->
 
     it 'extends nodes by style items', ->
         view = createView '''
-            <neft:style>
+            <style>
                 Item {
                     id: firstItem
                     document.query: 'test'
                 }
-            </neft:style>
+            </style>
             <test />
         '''
         view = view.clone()
 
         renderParse view
         testNode = view.node.query 'test'
-        assert.isNot testNode.attrs['neft:style'].indexOf('firstItem'), -1
+        assert.isNot testNode.attrs['n-style'].indexOf('firstItem'), -1
 
     it 'extends file node by main item if needed', ->
         view = createView '''
-            <neft:style>
+            <style>
                 Item {
                     id: firstItem
                 }
                 Item {
                     document.query: 'abc'
                 }
-            </neft:style>
+            </style>
         '''
         view = view.clone()
 
         renderParse view
-        assert.ok view.node.attrs['neft:style']
+        assert.ok view.node.attrs['n-style']
 
     it 'further declarations are merged', ->
         view = createView '''
-            <neft:style>
+            <style>
                 Item {
                     id: firstItem
                     document.query: 'test'
                 }
-            </neft:style>
-            <neft:style>
+            </style>
+            <style>
                 Item {
                     id: mainItem
                 }
-            </neft:style>
+            </style>
             <test />
         '''
         view = view.clone()
 
         renderParse view
         testNode = view.node.query 'test'
-        assert.isNot testNode.attrs['neft:style'].indexOf('firstItem'), -1
-        assert.ok view.node.attrs['neft:style']
-
-    describe '<style>', ->
-        it 'is not rendered', ->
-            view = createView '''
-                <style></style>
-            '''
-            view = view.clone()
-
-            renderParse view
-            assert.is view.node.stringify(), ''
-
-        it 'does not work if has attributes', ->
-            view = createView '''
-                <style src=""></style>
-            '''
-            view = view.clone()
-
-            renderParse view
-            assert.isNot view.node.stringify(), ''
-
-        it 'works as neft:style', ->
-            view = createView '''
-                <style>
-                    Item {
-                        id: firstItem
-                        document.query: 'test'
-                    }
-                </style>
-                <test />
-            '''
-            view = view.clone()
-
-            renderParse view
-            testNode = view.node.query 'test'
-            assert.isNot testNode.attrs['neft:style'].indexOf('firstItem'), -1
+        assert.isNot testNode.attrs['n-style'].indexOf('firstItem'), -1
+        assert.ok view.node.attrs['n-style']

--- a/tests/src/document/target.coffee
+++ b/tests/src/document/target.coffee
@@ -4,26 +4,28 @@
 {describe, it} = unit
 {createView, renderParse, uid} = require './utils'
 
-describe 'src/document neft:target', ->
-    it 'is replaced by the neft:use body', ->
-        source = createView """
-            <neft:fragment neft:name="a">
-                <neft:target />
-            </neft:fragment>
-            <neft:use neft:fragment="a"><b></b></neft:use>
-        """
+describe 'src/document target', ->
+    it 'is replaced by the use body', ->
+        source = createView '''
+            <fragment name="a">
+                <a1 />
+                <target />
+                <a2 />
+            </fragment>
+            <use fragment="a"><b></b></use>
+        '''
         view = source.clone()
 
         renderParse view
-        assert.is view.node.stringify(), '<b></b>'
+        assert.is view.node.stringify(), '<a1></a1><b></b><a2></a2>'
 
     it 'can be hidden', ->
-        source = createView """
-            <neft:fragment neft:name="a">
-                <neft:target neft:if="${props.x === 1}" />
-            </neft:fragment>
-            <neft:use neft:fragment="a" x="0"><b></b></neft:use>
-        """
+        source = createView '''
+            <fragment name="a">
+                <target n-if="${props.x === 1}" />
+            </fragment>
+            <use fragment="a" x="0"><b></b></use>
+        '''
         view = source.clone()
         elem = view.node.children[0]
 

--- a/tests/src/document/use.coffee
+++ b/tests/src/document/use.coffee
@@ -4,46 +4,50 @@
 {describe, it} = unit
 {createView, renderParse, uid} = require './utils'
 
-describe 'src/document neft:use', ->
-    it 'is replaced by neft:fragment', ->
-        view = createView """
-            <neft:fragment neft:name="a"><b></b></neft:fragment>
-            <neft:use neft:fragment="a" />
-        """
+describe 'src/document use', ->
+    it 'is replaced by fragment', ->
+        view = createView '''
+            <fragment name="a"><b></b></fragment>
+            <use fragment="a" />
+        '''
         view = view.clone()
 
         renderParse view
         assert.is view.node.stringify(), '<b></b>'
 
-    it 'is replaced in neft:fragment', ->
-        source = createView """
-            <neft:fragment neft:name="b">1</neft:fragment>
-            <neft:fragment neft:name="a"><neft:use neft:fragment="b" /></neft:fragment>
-            <neft:use neft:fragment="a" />
-        """
+    it 'is replaced in fragment', ->
+        source = createView '''
+            <fragment name="b">1</fragment>
+            <fragment name="a"><use fragment="b" /></fragment>
+            <use fragment="a" />
+        '''
         view = source.clone()
 
         renderParse view
         assert.is view.node.stringify(), '1'
 
     it 'can be rendered recursively', ->
-        source = createView """
-            <neft:fragment neft:name="a">
+        source = createView '''
+            <fragment name="a">
                 1
-                <neft:use neft:fragment="a" neft:if="${props.loops > 0}" loops="${props.loops - 1}" />
-            </neft:fragment>
-            <neft:use neft:fragment="a" loops="3" />
-        """
+                <use
+                  fragment="a"
+                  n-if="${props.loops > 0}"
+                  loops="${props.loops - 1}"
+                />
+            </fragment>
+            <use fragment="a" loops="3" />
+        '''
         view = source.clone()
 
         renderParse view
         assert.is view.node.stringify(), '1111'
 
-    it 'can be rendered using short use: syntax', ->
-        view = createView """
-            <neft:fragment neft:name="a-b"><b></b></neft:fragment>
-            <use:a-b />
-        """
+    it 'can be rendered using short syntax', ->
+        view = createView '''
+            <fragment name="a-b"><b></b></fragment>
+            <a-b />
+        '''
         view = view.clone()
 
         renderParse view

--- a/tests/src/document/utils.coffee
+++ b/tests/src/document/utils.coffee
@@ -2,7 +2,7 @@
 
 {Document, utils} = Neft
 
-VIEWS_CACHE_FILE = "tmp/views.json"
+VIEWS_CACHE_FILE = 'tmp/views.json'
 
 loaded = false
 

--- a/tests/src/styles/style.coffee
+++ b/tests/src/styles/style.coffee
@@ -28,11 +28,11 @@ render = (opts) ->
     doc.render()
 
 describe 'src/styles', ->
-    describe "neft:style", ->
+    describe "n-style", ->
         it "can be a Renderer.Item instance", ->
             # item = Renderer.Rectangle.New()
             # node = new Element.Tag
-            # node.attrs['neft:style'] = item
+            # node.attrs['n-style'] = item
             # doc = render
             #   node: node
 
@@ -42,14 +42,14 @@ describe 'src/styles', ->
 
         it "accepts 'renderer:' prefix", ->
             doc = render
-                html: """<b neft:style="renderer:Rectangle" />"""
+                html: """<b n-style="renderer:Rectangle" />"""
 
             assert.is doc.styles.length, 1
             assert.instanceOf (style = doc.styles[0]).item, Renderer.Rectangle
 
         it "accepts 'styles:file' syntax", ->
             doc = render
-                html: """<b neft:style="styles:file" />"""
+                html: """<b n-style="styles:file" />"""
                 styles:
                     file:
                         _main:
@@ -61,7 +61,7 @@ describe 'src/styles', ->
 
         it "accepts 'styles:file:style' syntax", ->
             doc = render
-                html: """<b neft:style="styles:file:style" />"""
+                html: """<b n-style="styles:file:style" />"""
                 styles:
                     file:
                         style:
@@ -73,9 +73,9 @@ describe 'src/styles', ->
 
         it "accepts 'styles:file:style:subid' syntax", ->
             doc = render
-                html: """<b neft:style="styles:file:style">
-                    <div neft:style="renderer:Item">
-                        <i neft:style="styles:file:style:subid" />
+                html: """<b n-style="styles:file:style">
+                    <div n-style="renderer:Item">
+                        <i n-style="styles:file:style:subid" />
                     </div>
                 </b>"""
                 styles:
@@ -95,7 +95,7 @@ describe 'src/styles', ->
 
         it "accepts 'styles:view:style:subid' syntax", ->
             doc = render
-                html: """<b neft:style="styles:view:style:subid" />"""
+                html: """<b n-style="styles:view:style:subid" />"""
                 windowStyle:
                     objects:
                         subid: Renderer.Text.New()
@@ -105,14 +105,14 @@ describe 'src/styles', ->
 
         it "created style is accessible in node", ->
             doc = render
-                html: """<b neft:style="renderer:Item" />"""
+                html: """<b n-style="renderer:Item" />"""
 
             assert.is (node = doc.styles[0].node).name, 'b'
             assert.instanceOf node.style, Renderer.Item
 
         it "node is accessible in created style document", ->
             doc = render
-                html: """<b neft:style="renderer:Item" />"""
+                html: """<b n-style="renderer:Item" />"""
 
             bNode = doc.node.query 'b'
             assert.is bNode.style.document.node, bNode
@@ -129,7 +129,7 @@ describe 'src/styles', ->
     describe "Renderer.Text::text", ->
         it "is always equal of stringified node children", ->
             doc = render
-                html: """<b neft:style="renderer:Text">ab<i>c</i></b>"""
+                html: """<b n-style="renderer:Text">ab<i>c</i></b>"""
 
             node = doc.node.query 'b'
             item = doc.styles[0].item
@@ -141,7 +141,7 @@ describe 'src/styles', ->
 
         it "is always equal of stringified visible node children", ->
             doc = render
-                html: """<b neft:style="renderer:Text">ab<i visible="false">c</i></b>"""
+                html: """<b n-style="renderer:Text">ab<i visible="false">c</i></b>"""
 
             bNode = doc.node.query 'b'
             iNode = doc.node.query 'i'
@@ -155,7 +155,7 @@ describe 'src/styles', ->
     describe "Renderer.Item::$.text", ->
         it "is always equal stringified node children", ->
             doc = render
-                html: """<b neft:style="styles:file">ab<i>c</i></b>"""
+                html: """<b n-style="styles:file">ab<i>c</i></b>"""
                 styles:
                     file:
                         _main:
@@ -174,7 +174,7 @@ describe 'src/styles', ->
 
         it "is more important than ::text property", ->
             doc = render
-                html: """<b neft:style="styles:file">ab<i>c</i></b>"""
+                html: """<b n-style="styles:file">ab<i>c</i></b>"""
                 styles:
                     file:
                         _main:
@@ -219,7 +219,7 @@ describe 'src/styles', ->
 
         it "is not created if has a text parent", ->
             doc = render
-                html: """<b neft:style="styles:file">ab</b>"""
+                html: """<b n-style="styles:file">ab</b>"""
                 styles:
                     file:
                         _main:
@@ -235,9 +235,9 @@ describe 'src/styles', ->
             assert.isNotDefined textNode.style
 
     describe "a[href]", ->
-        it "sets style linkUri", ->
+        it 'sets style linkUri', ->
             doc = render
-                html: """<a href="/abc" neft:style="renderer:Item"></a>"""
+                html: '<a href="/abc" n-style="renderer:Item"></a>'
 
             node = doc.node.query 'a'
 
@@ -245,9 +245,9 @@ describe 'src/styles', ->
             assert.instanceOf style = node.style, Renderer.Item
             assert.is style.linkUri, node.attrs.href
 
-        it "sets child node style linkUri", ->
+        it 'sets child node style linkUri', ->
             doc = render
-                html: """<a href="/abc"><b neft:style="renderer:Item" /></a>"""
+                html: '<a href="/abc"><b n-style="renderer:Item" /></a>'
 
             aNode = doc.node.query 'a'
             bNode = doc.node.query 'b'
@@ -258,27 +258,27 @@ describe 'src/styles', ->
 
         it "doesn't set child node style linkUri if the parent node is styled", ->
             doc = render
-                html: """<a href="/abc" neft:style="renderer:Item">
-                    <b neft:style="renderer:Item" />
-                </a>"""
+                html: '''<a href="/abc" n-style="renderer:Item">
+                    <b n-style="renderer:Item" />
+                </a>'''
 
             aNode = doc.node.query 'a'
             bNode = doc.node.query 'b'
 
             assert.is bNode.style.linkUri, ''
 
-        it "updates style linkUri on attr change", ->
+        it 'updates style linkUri on attr change', ->
             doc = render
-                html: """<a href="/abc" neft:style="renderer:Item"></a>"""
+                html: '<a href="/abc" n-style="renderer:Item"></a>'
 
             node = doc.node.query 'a'
             node.attrs.set 'href', '/123'
 
             assert.is node.style.linkUri, node.attrs.href
 
-        it "updates style linkUri on parent change", ->
+        it 'updates style linkUri on parent change', ->
             doc = render
-                html: """<a href="/abc"><div /></a><b neft:style="renderer:Item" />"""
+                html: '<a href="/abc"><div /></a><b n-style="renderer:Item" />'
 
             aNode = doc.node.query 'a'
             divNode = doc.node.query 'div'
@@ -292,9 +292,11 @@ describe 'src/styles', ->
             bNode.parent = null
             assert.is bNode.style.linkUri, ''
 
-        it "updates child style linkUri on attr change", ->
+        it 'updates child style linkUri on attr change', ->
             doc = render
-                html: """<a href="/abc"><div><b neft:style="renderer:Item" /></div></a>"""
+                html: '''
+                    <a href="/abc"><div><b n-style="renderer:Item" /></div></a>
+                '''
 
             aNode = doc.node.query 'a'
             bNode = doc.node.query 'b'
@@ -302,89 +304,89 @@ describe 'src/styles', ->
             aNode.attrs.set 'href', '/123'
             assert.is bNode.style.linkUri, aNode.attrs.href
 
-        it "updates neft:each styles", ->
+        it 'updates n-each styles', ->
             test = ->
                 for child in ulNode.children
                     assert.is child.query('#text').style?.linkUri, child.query('a').attrs.href
                 return
 
             doc = render
-                html: """<ul neft:each="[1,2]">
+                html: '''<ul n-each="[1,2]">
                     <a href="/${props.item}">${props.item}</a>
-                </ul>"""
+                </ul>'''
 
             ulNode = doc.node.query 'ul'
 
             test()
 
-            ulNode.attrs.set 'neft:each', [5,6,7]
+            ulNode.attrs.set 'n-each', [5, 6, 7]
             test()
 
-    describe "'style:' attributes", ->
-        it "are set on a style item", ->
+    describe "'n-style:' attributes", ->
+        it 'are set on a style item', ->
             doc = render
-                html: """<b neft:style="renderer:Item" style:x="50" />"""
+                html: '<b n-style="renderer:Item" n-style:x="50" />'
 
             {node, item} = doc.styles[0]
 
             assert.instanceOf item, Renderer.Item
-            assert.is item.x, node.attrs['style:x']
+            assert.is item.x, node.attrs['n-style:x']
 
-        it "on change are set on a style item", ->
+        it 'on change are set on a style item', ->
             doc = render
-                html: """<b neft:style="renderer:Item" style:x="50" />"""
+                html: '<b n-style="renderer:Item" n-style:x="50" />'
 
             {node, item} = doc.styles[0]
 
             node.attrs.set 'style:x', 70
-            assert.is item.x, node.attrs['style:x']
+            assert.is item.x, node.attrs['n-style:x']
 
         it "'null' value is not set for non-object properties", ->
             doc = render
-                html: """<b neft:style="renderer:Item" style:x="null" />"""
+                html: '<b n-style="renderer:Item" n-style:x="null" />'
 
             {node, item} = doc.styles[0]
 
             assert.is item.x, 0
 
-            node.attrs.set 'style:x', 4
-            node.attrs.set 'style:x', null
+            node.attrs.set 'n-style:x', 4
+            node.attrs.set 'n-style:x', null
             assert.is item.x, 4
 
     describe "'class' attribute", ->
-        it "sets item classes", ->
+        it 'sets item classes', ->
             doc = render
-                html: """<b neft:style="renderer:Item" class="a b c" />"""
+                html: '<b n-style="renderer:Item" class="a b c" />'
 
             {node, item} = doc.styles[0]
 
             assert.isEqual item.classes.toArray(), node.attrs.class.split(' ')
 
-        it "synchronizes item classes on add and remove", ->
+        it 'synchronizes item classes on add and remove', ->
             doc = render
-                html: """<b neft:style="renderer:Item" class="a b c" />"""
+                html: '<b n-style="renderer:Item" class="a b c" />'
 
             {node, item} = doc.styles[0]
 
             node.attrs.set 'class', 'g a c'
             assert.isEqual item.classes.toArray(), node.attrs.class.split(' ')
 
-    describe "Style item visible", ->
+    describe 'Style item visible', ->
         it "is 'true' by default", ->
             doc = render
-                html: """<b neft:style="renderer:Item" />"""
+                html: '<b n-style="renderer:Item" />'
 
             assert.is doc.styles[0].item.visible, true
 
         it "is 'false' if the style node is invisible", ->
             doc = render
-                html: """<b neft:style="renderer:Item" visible="false" />"""
+                html: '<b n-style="renderer:Item" visible="false" />'
 
             assert.is doc.styles[0].item.visible, false
 
         it "is 'false' if the style node comes invisible", ->
             doc = render
-                html: """<b neft:style="renderer:Item" />"""
+                html: '<b n-style="renderer:Item" />'
 
             node = doc.node.query 'b'
 
@@ -393,7 +395,7 @@ describe 'src/styles', ->
 
         it "is 'true' if the style node comes visible", ->
             doc = render
-                html: """<b neft:style="renderer:Item" visible="false" />"""
+                html: '<b n-style="renderer:Item" visible="false" />'
 
             node = doc.node.query 'b'
 
@@ -402,16 +404,16 @@ describe 'src/styles', ->
 
         it "is 'false' if the not-styled node parent is invisible", ->
             doc = render
-                html: """<div visible="false">
-                    <div><b neft:style="renderer:Item" /></div>
-                </div>"""
+                html: '''<div visible="false">
+                    <div><b n-style="renderer:Item" /></div>
+                </div>'''
 
             assert.is doc.styles[0].item.visible, false
 
         it "is 'false' if the not-styled node parent comes invisible", ->
             doc = render
                 html: """<div>
-                    <div><b neft:style="renderer:Item" /></div>
+                    <div><b n-style="renderer:Item" /></div>
                 </div>"""
 
             node = doc.node.query 'div'
@@ -421,8 +423,8 @@ describe 'src/styles', ->
 
         it "is 'true' if the styled node parent is invisible", ->
             doc = render
-                html: """<div neft:style="renderer:Rectangle" visible="false">
-                    <div><b neft:style="renderer:Item" /></div>
+                html: """<div n-style="renderer:Rectangle" visible="false">
+                    <div><b n-style="renderer:Item" /></div>
                 </div>"""
 
             bNode = doc.node.query 'b'
@@ -431,8 +433,8 @@ describe 'src/styles', ->
 
         it "is 'true' if the styled node parent comes invisible", ->
             doc = render
-                html: """<div neft:style="renderer:Rectangle">
-                    <div><b neft:style="renderer:Item" /></div>
+                html: """<div n-style="renderer:Rectangle">
+                    <div><b n-style="renderer:Item" /></div>
                 </div>"""
 
             divNode = doc.node.query 'div'
@@ -444,8 +446,8 @@ describe 'src/styles', ->
     describe "Style item parent", ->
         it "refers to the first styled parent style", ->
             doc = render
-                html: """<div neft:style="renderer:Item">
-                    <b neft:style="renderer:Item" />
+                html: """<div n-style="renderer:Item">
+                    <b n-style="renderer:Item" />
                 </div>"""
 
             divNode = doc.node.query 'div'
@@ -455,10 +457,10 @@ describe 'src/styles', ->
 
         it "refers to the first styled parent style after the parent change", ->
             doc = render
-                html: """<div neft:style="renderer:Item">
+                html: """<div n-style="renderer:Item">
                     <i />
                 </div>
-                <b neft:style="renderer:Item" />"""
+                <b n-style="renderer:Item" />"""
 
             divNode = doc.node.query 'div'
             iNode = doc.node.query 'i'
@@ -467,14 +469,14 @@ describe 'src/styles', ->
             bNode.parent = iNode
             assert.is bNode.style.parent, divNode.style
 
-        it "is properly synchronized on 'neft:use'", ->
+        it "is properly synchronized on 'use'", ->
             doc = render
-                html: """<neft:fragment neft:name="a">
-                    <b neft:style="renderer:Item" />
-                    <i neft:style="renderer:Item" />
-                </neft:fragment>
-                <div neft:style="renderer:Item">
-                    <neft:use neft:fragment="a" />
+                html: """<fragment name="a">
+                    <b n-style="renderer:Item" />
+                    <i n-style="renderer:Item" />
+                </fragment>
+                <div n-style="renderer:Item">
+                    <use fragment="a" />
                 </div>"""
 
             divNode = doc.node.query 'div'
@@ -486,8 +488,8 @@ describe 'src/styles', ->
 
         it "doesn't change if the item has a parent", ->
             doc = render
-                html: """<div neft:style="renderer:Item"></div>
-                <b neft:style="styles:file:style" />"""
+                html: """<div n-style="renderer:Item"></div>
+                <b n-style="styles:file:style" />"""
                 styles:
                     file:
                         style:
@@ -509,10 +511,10 @@ describe 'src/styles', ->
         describe "is valid on", ->
             it "index change", ->
                 doc = render
-                    html: """<div neft:style="renderer:Item">
-                        <em neft:style="renderer:Item" />
-                        <b neft:style="renderer:Item" />
-                        <i neft:style="renderer:Item" />
+                    html: """<div n-style="renderer:Item">
+                        <em n-style="renderer:Item" />
+                        <b n-style="renderer:Item" />
+                        <i n-style="renderer:Item" />
                     </div>"""
 
                 divNode = doc.node.query 'div'
@@ -526,11 +528,11 @@ describe 'src/styles', ->
 
             it "parent change", ->
                 doc = render
-                    html: """<div neft:style="renderer:Item">
+                    html: """<div n-style="renderer:Item">
                         <em />
-                        <b neft:style="renderer:Item" />
+                        <b n-style="renderer:Item" />
                     </div>
-                    <i neft:style="renderer:Item" />"""
+                    <i n-style="renderer:Item" />"""
 
                 divNode = doc.node.query 'div'
                 emNode = doc.node.query 'em'
@@ -540,16 +542,16 @@ describe 'src/styles', ->
                 iNode.parent = emNode
                 assert.is iNode.style.nextSibling, bNode.style
 
-        it "is valid in neft:each", ->
+        it "is valid in n-each", ->
             test = ->
                 childItem = divNode.style.children.firstChild
-                for item in divNode.attrs['neft:each']
+                for item in divNode.attrs['n-each']
                     assert.is childItem.text, item+''
                     childItem = childItem.nextSibling
                 return
 
             doc = render
-                html: """<div neft:style="renderer:Item" neft:each="[1,2,3]">
+                html: """<div n-style="renderer:Item" n-each="[1,2,3]">
                     <b>${props.item}</b>
                 </div>"""
 
@@ -557,15 +559,15 @@ describe 'src/styles', ->
 
             test()
 
-            divNode.attrs.set 'neft:each', [5,6,7,8]
+            divNode.attrs.set 'n-each', [5,6,7,8]
             test()
             return
 
         it "is valid for fixed item parent", ->
             doc = render
-                html: """<b neft:style="styles:file:style">
-                    <em neft:style="renderer:Item" />
-                    <i neft:style="styles:file:style:subid" />
+                html: """<b n-style="styles:file:style">
+                    <em n-style="renderer:Item" />
+                    <i n-style="styles:file:style:subid" />
                 </b>"""
                 styles:
                     file:


### PR DESCRIPTION
All 'neft:' prefixes from tag names have been removed.
All 'neft:' prefixes from attribute names have been replaced as 'n-'.
'neft:require' -> 'import'
'style:' -> 'n-style:'

Issue #104 