### PR TITLE
Loading multiple images at the same time on ios fixed

### DIFF
--- a/runtimes/ios/Neft/Image.swift
+++ b/runtimes/ios/Neft/Image.swift
@@ -95,6 +95,7 @@ class Image: Item {
         var loading = Image.loadingHandlers[val]
         if loading != nil {
             loading!.append(onCompletion)
+            Image.loadingHandlers[val] = loading!
             return
         }
 
@@ -126,10 +127,10 @@ class Image: Item {
             }
 
             let loading = Image.loadingHandlers[val]
+            Image.loadingHandlers.removeValue(forKey: val)
             for handler in loading! {
                 handler(img)
             }
-            Image.loadingHandlers.removeValue(forKey: val)
         }
     }
 


### PR DESCRIPTION
Arrays in Swift are structs and are not passing by the reference.

When we requested for an image which has been already loading,
we added the callback into an array. Updated array was not properly saved.
Now it's fixed.