### PR TITLE
EventLoop: Faster immediate updates

### DIFF
--- a/cli/tasks/build/server/parse/index.coffee
+++ b/cli/tasks/build/server/parse/index.coffee
@@ -62,6 +62,7 @@ module.exports = (platform, app, options) ->
 
     # create file
     file = ''
+    file += "Neft.eventLoop.lock()\n"
     file += "var opts = #{config};\n"
     file += 'opts.modules = typeof modules !== \'undefined\' ? modules : {};\n'
 
@@ -73,5 +74,6 @@ module.exports = (platform, app, options) ->
         file += 'module.exports = init(Neft.bind(null, opts));\n'
     else
         file += 'module.exports = Neft(opts);\n'
+    file += "Neft.eventLoop.release();\n"
 
     file

--- a/index.coffee
+++ b/index.coffee
@@ -14,6 +14,7 @@ exports.Document = require 'src/document'
 exports.styles = require 'src/styles'
 exports.assert = require 'src/assert'
 exports.db = require 'src/db'
+exports.eventLoop = require 'src/eventLoop'
 exports.Binding = require 'src/binding'
 
 if exports.utils.isClient and not exports.utils.isBrowser

--- a/src/document/element/element/tag/query.coffee
+++ b/src/document/element/element/tag/query.coffee
@@ -2,6 +2,7 @@
 
 utils = require 'src/utils'
 signal = require 'src/signal'
+eventLoop = require 'src/eventLoop'
 assert = require 'src/assert'
 
 {emitSignal} = signal.Emitter
@@ -526,7 +527,7 @@ module.exports = (Element, _Tag) ->
                 watcher.nodesWillChange = false
             return
 
-        (node, parent=node._parent) ->
+        (node, parent = node._parent) ->
             # mark this node
             node._checkWatchers |= CHECK_WATCHERS_THIS
             if node instanceof Tag
@@ -550,8 +551,8 @@ module.exports = (Element, _Tag) ->
 
             # run update
             unless pending
-                setImmediate updateWatchers
                 pending = true
+                eventLoop.setImmediate updateWatchers
             return
 
 module.exports.getSelectorCommandsLength = (selector, beginQuery=0, endQuery=Infinity) ->

--- a/src/document/index.litcoffee
+++ b/src/document/index.litcoffee
@@ -6,6 +6,7 @@
     assert = require 'src/assert'
     log = require 'src/log'
     signal = require 'src/signal'
+    eventLoop = require 'src/eventLoop'
     Dict = require 'src/dict'
     List = require 'src/list'
 
@@ -325,7 +326,10 @@ Corresponding node handler: *n-onRevert=""*.
             unless @isClone
                 @clone().render props, context, source, refs
             else
-                @_render(props, context, source, refs)
+                eventLoop.lock()
+                result = @_render(props, context, source, refs)
+                eventLoop.release()
+                result
 
         _updateInputPropsKey: (key) ->
             {inputProps, source, props} = @

--- a/src/document/input.coffee
+++ b/src/document/input.coffee
@@ -4,6 +4,7 @@ utils = require 'src/utils'
 assert = require 'src/assert'
 log = require 'src/log'
 signal = require 'src/signal'
+eventLoop = require 'src/eventLoop'
 Dict = require 'src/dict'
 List = require 'src/list'
 Binding = require 'src/binding'
@@ -65,7 +66,10 @@ class DocumentBinding extends Binding
         `//<development>`
         @failed = false
         `//</development>`
+        eventLoop.lock()
         super()
+        eventLoop.release()
+        return
 
     getValue: ->
         @ctx.getValue()

--- a/src/document/iterator.coffee
+++ b/src/document/iterator.coffee
@@ -4,7 +4,7 @@ utils = require 'src/utils'
 assert = require 'src/assert'
 List = require 'src/list'
 log = require 'src/log'
-signal = require 'src/signal'
+eventLoop = require 'src/eventLoop'
 
 {isArray} = Array
 
@@ -77,7 +77,7 @@ module.exports = (File) -> class Iterator
     renderImmediate: ->
         unless @isRenderPending
             @isRenderPending = true
-            signal.setImmediate @_renderImmediateCallback
+            eventLoop.setImmediate @_renderImmediateCallback
         return
 
     _renderImmediateCallback: ->

--- a/src/document/log.coffee
+++ b/src/document/log.coffee
@@ -4,7 +4,7 @@
 
 utils = require 'src/utils'
 assert = require 'src/assert'
-signal = require 'src/signal'
+eventLoop = require 'src/eventLoop'
 
 module.exports = (File) -> class Log
     @__name__ = 'Log'
@@ -52,7 +52,7 @@ module.exports = (File) -> class Log
     render: ->
         unless @isRenderPending
             @isRenderPending = true
-            signal.setImmediate @log
+            eventLoop.setImmediate @log
         return
 
     log: ->

--- a/src/document/use.coffee
+++ b/src/document/use.coffee
@@ -3,7 +3,7 @@
 utils = require 'src/utils'
 assert = require 'src/assert'
 log = require 'src/log'
-signal = require 'src/signal'
+eventLoop = require 'src/eventLoop'
 
 assert = assert.scope 'View.Use'
 log = log.scope 'View', 'Use'
@@ -88,7 +88,7 @@ module.exports = (File) -> class Use
     renderImmediate: ->
         unless @isRenderPending
             @isRenderPending = true
-            signal.setImmediate @_renderImmediateCallback
+            eventLoop.setImmediate @_renderImmediateCallback
         return
 
     _renderImmediateCallback: ->

--- a/src/eventLoop/index.coffee
+++ b/src/eventLoop/index.coffee
@@ -1,0 +1,30 @@
+'use strict'
+
+assert = require 'src/assert'
+
+immediate = []
+pending = 0
+
+exports.lock = ->
+    pending += 1
+
+exports.release = ->
+    pending -= 1
+    if pending is 0 and immediate.length > 0
+        exports.lock()
+        for i in [0...immediate.length] by 1
+            immediate.shift()()
+        exports.release()
+    return
+
+# Register a function which will be called when all locks will be released.
+# If there is no pending locks, the given function is calling immediately.
+exports.setImmediate = (callback) ->
+    assert.isFunction callback, """
+        eventLoop.setImmediate callback must be a function, but #{callback} given
+    """
+    if pending is 0
+        callback()
+    else
+        immediate.push callback
+    return

--- a/src/renderer/impl/base/level0/item/pointer.coffee
+++ b/src/renderer/impl/base/level0/item/pointer.coffee
@@ -2,6 +2,7 @@
 
 utils = require 'src/utils'
 signal = require 'src/signal'
+eventLoop = require 'src/eventLoop'
 
 {sin, cos} = Math
 {emitSignal} = signal.Emitter
@@ -158,6 +159,7 @@ module.exports = (impl) ->
                 PROPAGATE_UP | STOP_ASIDE_PROPAGATION
 
             (e) ->
+                eventLoop.lock()
                 event._stopPropagation = false
                 event._checkSiblings = false
 
@@ -181,6 +183,7 @@ module.exports = (impl) ->
                 utils.clear itemsToRelease
                 utils.clear itemsToMove
                 utils.clear pressedItems
+                eventLoop.release()
                 return
 
         # support move, enter and exit events
@@ -205,6 +208,7 @@ module.exports = (impl) ->
                 PROPAGATE_UP | STOP_ASIDE_PROPAGATION
 
             (e) ->
+                eventLoop.lock()
                 event._stopPropagation = false
                 event._checkSiblings = false
                 flag = (flag % 2) + 1
@@ -231,6 +235,7 @@ module.exports = (impl) ->
                     if data.pointerMoveFlag isnt flag
                         data.pointerMoveFlag = flag
 
+                eventLoop.release()
                 return
 
         # support wheel event
@@ -246,8 +251,10 @@ module.exports = (impl) ->
                 PROPAGATE_UP | STOP_ASIDE_PROPAGATION
 
             (e) ->
+                eventLoop.lock()
                 event._checkSiblings = false
                 captureItems impl.window, e._x, e._y, onItem
+                eventLoop.release()
                 return
 
     i = 0

--- a/src/renderer/impl/base/level1/anchors.coffee
+++ b/src/renderer/impl/base/level1/anchors.coffee
@@ -3,6 +3,7 @@
 assert = require 'src/assert'
 log = require 'src/log'
 utils = require 'src/utils'
+eventLoop = require 'src/eventLoop'
 
 log = log.scope 'Renderer', 'Anchors'
 
@@ -36,8 +37,8 @@ module.exports = (impl) ->
         @pending = true
         queue.push @
         unless pending
-            setImmediate updateItems
             pending = true
+            eventLoop.setImmediate updateItems
         return
 
     getItemProp =

--- a/src/renderer/impl/base/level1/animation/number.coffee
+++ b/src/renderer/impl/base/level1/animation/number.coffee
@@ -2,6 +2,7 @@
 
 utils = require 'src/utils'
 assert = require 'src/assert'
+eventLoop = require 'src/eventLoop'
 
 module.exports = (impl) ->
     {Types} = impl
@@ -12,6 +13,8 @@ module.exports = (impl) ->
     nowTime = now()
 
     vsync = ->
+        eventLoop.lock()
+        requestAnimationFrame vsync
         nowTime = now()
 
         i = 0; n = pending.length
@@ -24,13 +27,12 @@ module.exports = (impl) ->
             else
                 # remove element in not ordered list
                 # this array may change due loop
-                pending[i] = pending[n-1]
-                pending[n-1] = pending[pending.length-1]
+                pending[i] = pending[n - 1]
+                pending[n - 1] = pending[pending.length - 1]
                 pending.pop()
                 anim._impl.pending = false
                 n--
-
-        requestAnimationFrame vsync
+        eventLoop.release()
         return
     requestAnimationFrame? vsync
 

--- a/src/renderer/impl/base/level1/binding.coffee
+++ b/src/renderer/impl/base/level1/binding.coffee
@@ -1,5 +1,6 @@
 'use strict'
 
+eventLoop = require 'src/eventLoop'
 Binding = require 'src/binding'
 
 module.exports = (impl) ->
@@ -41,6 +42,12 @@ module.exports = (impl) ->
                 impl.Renderer.window
             else
                 @component.objects[item] or impl.Renderer[item] or null
+
+        update: ->
+            eventLoop.lock()
+            super()
+            eventLoop.release()
+            return
 
         getValue: ->
             @obj[@prop]

--- a/src/renderer/impl/base/level1/flow.coffee
+++ b/src/renderer/impl/base/level1/flow.coffee
@@ -2,6 +2,7 @@
 
 utils = require 'src/utils'
 log = require 'src/log'
+eventLoop = require 'src/eventLoop'
 TypedArray = require 'src/typed-array'
 
 log = log.scope 'Renderer', 'Flow'
@@ -352,8 +353,8 @@ update = ->
     queue.push @
 
     unless pending
-        setImmediate updateItems
         pending = true
+        eventLoop.setImmediate updateItems
     return
 
 updateSize = ->

--- a/src/renderer/impl/base/utils/grid.coffee
+++ b/src/renderer/impl/base/utils/grid.coffee
@@ -4,6 +4,7 @@ MAX_LOOPS = 100
 
 utils = require 'src/utils'
 log = require 'src/log'
+eventLoop = require 'src/eventLoop'
 TypedArray = require 'src/typed-array'
 
 log = log.scope 'Renderer'
@@ -343,8 +344,8 @@ update = ->
     queue.push @
 
     unless pending
-        setImmediate updateItems
         pending = true
+        eventLoop.setImmediate updateItems
     return
 
 updateSize = ->

--- a/src/renderer/impl/css/level0/text.coffee
+++ b/src/renderer/impl/css/level0/text.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
 utils = require 'src/utils'
-signal = require 'src/signal'
+eventLoop = require 'src/eventLoop'
 
 module.exports = (impl) ->
     {Item, Image} = impl.Types
@@ -177,8 +177,8 @@ module.exports = (impl) ->
             data.contentUpdatePending = true
 
             unless pending
-                setImmediate updateAll
                 pending = true
+                eventLoop.setImmediate updateAll
             return
 
     updateTextStyle = (item) ->

--- a/src/renderer/impl/native/android.coffee
+++ b/src/renderer/impl/native/android.coffee
@@ -16,6 +16,7 @@ module.exports = (impl) ->
         vsync = ->
             requestAnimationFrame vsync
             nativeBridge.sendData()
+            return
 
         requestAnimationFrame vsync
 

--- a/src/renderer/impl/native/level0/text.coffee
+++ b/src/renderer/impl/native/level0/text.coffee
@@ -1,5 +1,7 @@
 'use strict'
 
+eventLoop = require 'src/eventLoop'
+
 module.exports = (impl) ->
     {bridge} = impl
     {outActions, pushAction, pushItem, pushBoolean, pushInteger, pushFloat, pushString} = bridge
@@ -39,8 +41,8 @@ module.exports = (impl) ->
             queue.push item
 
             unless pending
-                setImmediate updateAll
                 pending = true
+                eventLoop.setImmediate updateAll
             return
 
     DATA =

--- a/src/renderer/impl/pixi/level0/text.coffee
+++ b/src/renderer/impl/pixi/level0/text.coffee
@@ -1,6 +1,7 @@
 'use strict'
 
 utils = require 'src/utils'
+eventLoop = require 'src/eventLoop'
 PIXI = require '../pixi.lib.js'
 
 module.exports = (impl) ->
@@ -44,8 +45,8 @@ module.exports = (impl) ->
             queue.push item
 
             unless pending
-                setImmediate updateAll
                 pending = true
+                eventLoop.setImmediate updateAll
             return
 
     updateAlignment = (item) ->

--- a/src/signal/index.litcoffee
+++ b/src/signal/index.litcoffee
@@ -12,8 +12,6 @@ const { signal } = Neft;
     utils = require 'src/utils'
     assert = require 'src/assert'
 
-    pendingSignals = 0
-
 ## *Integer* signal.STOP_PROPAGATION
 
 Special constant used to stop calling further listeners.
@@ -83,25 +81,7 @@ Returns `true` if the given signal has no listeners.
                 return false
         return true
 
-## signal.setImmediate(*Function* callback)
-
-Register a function which will be called when all pending signal emits will be finished.
-
-If there is no pending emits, the given function is calling immediately.
-
-    immediate = []
-    exports.setImmediate = (callback) ->
-        assert.isFunction callback, """
-            signal.setImmediate callback must be a function, but #{callback} given
-        """
-        if pendingSignals is 0
-            callback()
-        else
-            immediate.push callback
-
     callSignal = (obj, listeners, arg1, arg2) ->
-        pendingSignals += 1
-
         i = 0
         n = listeners.length
         result = 0
@@ -132,12 +112,6 @@ If there is no pending emits, the given function is calling immediately.
                     listeners[i] = null
                     listeners[i + 1] = null
                 i += 2
-
-        pendingSignals -= 1
-
-        if pendingSignals is 0
-            while callback = immediate.shift()
-                callback()
 
         result
 

--- a/tests/integration/src/document/element/index.server.coffee
+++ b/tests/integration/src/document/element/index.server.coffee
@@ -330,200 +330,171 @@ describe 'Document Element', ->
                 doc2em1 = doc2div2.children[0].children[0]
                 doc2em2 = doc2div2.children[1]
 
-            it 'E', (done) ->
+            it 'E', ->
                 doc2b.parent = null
                 watcher = doc2.watch 'b'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 doc2b.parent = doc2div1
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2b], maxDeep: 1
-                    done()
+                assert.isEqual tags, [doc2b], maxDeep: 1
 
-            it 'E F', (done) ->
+            it 'E F', ->
                 doc2u.parent = null
                 watcher = doc2.watch 'b u'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 doc2u.parent = doc2b
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2u, doc2u2], maxDeep: 1
-                    done()
+                assert.isEqual tags, [doc2u, doc2u2], maxDeep: 1
 
-            it 'E > F', (done) ->
+            it 'E > F', ->
                 doc2u.parent = null
                 watcher = doc2div1.watch '> u'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 doc2u.parent = doc2div1
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2u], maxDeep: 1
-                    done()
+                assert.isEqual tags, [doc2u], maxDeep: 1
 
-            it '[foo]', (done) ->
+            it '[foo]', ->
                 watcher = doc2div1.watch '[attr2]'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 watcher.onRemove (tag) ->
                     utils.remove tags, tag
                 doc2u.props.set 'attr2', '2'
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2u], maxDeep: 1
-                    doc2u.props.set 'attr2', undefined
-                    whenChange tags, ->
-                        assert.isEqual tags, []
-                        done()
+                assert.isEqual tags, [doc2u], maxDeep: 1
+                doc2u.props.set 'attr2', undefined
+                assert.isEqual tags, []
 
-            it '[foo=bar]', (done) ->
+            it '[foo=bar]', ->
                 watcher = doc2div1.watch '[attr=2]'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 watcher.onRemove (tag) ->
                     utils.remove tags, tag
                 doc2u.props.set 'attr', '2'
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2u], maxDeep: 1
-                    doc2u.props.set 'attr', '1'
-                    whenChange tags, ->
-                        assert.isEqual tags, []
-                        done()
+                assert.isEqual tags, [doc2u], maxDeep: 1
+                doc2u.props.set 'attr', '1'
+                assert.isEqual tags, []
 
-            it '[foo^=bar]', (done) ->
+            it '[foo^=bar]', ->
                 watcher = doc2div1.watch '[color^=re]'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 watcher.onRemove (tag) ->
                     utils.remove tags, tag
                 doc2u.props.set 'color', 'red'
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2u], maxDeep: 1
-                    doc2u.props.set 'color', 'blue'
-                    whenChange tags, ->
-                        assert.isEqual tags, []
-                        done()
+                assert.isEqual tags, [doc2u], maxDeep: 1
+                doc2u.props.set 'color', 'blue'
+                assert.isEqual tags, []
 
-            it '[foo$=bar]', (done) ->
+            it '[foo$=bar]', ->
                 watcher = doc2div1.watch '[color$=ed]'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 watcher.onRemove (tag) ->
                     utils.remove tags, tag
                 doc2u.props.set 'color', 'red'
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2u], maxDeep: 1
-                    doc2u.props.set 'color', 'blue'
-                    whenChange tags, ->
-                        assert.isEqual tags, []
-                        done()
+                assert.isEqual tags, [doc2u], maxDeep: 1
+                doc2u.props.set 'color', 'blue'
+                assert.isEqual tags, []
 
-            it '[foo*=bar]', (done) ->
+            it '[foo*=bar]', ->
                 watcher = doc2div1.watch '[color*=rang]'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 watcher.onRemove (tag) ->
                     utils.remove tags, tag
                 doc2u.props.set 'color', 'orange'
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2u], maxDeep: 1
-                    doc2u.props.set 'color', 'blue'
-                    whenChange tags, ->
-                        assert.isEqual tags, []
-                        done()
+                assert.isEqual tags, [doc2u], maxDeep: 1
+                doc2u.props.set 'color', 'blue'
+                assert.isEqual tags, []
 
-            it '*', (done) ->
+            it '*', ->
                 doc2u.parent = null
                 watcher = doc2div1.watch '*'
-                for node in watcher.nodes
-                    tags.push node
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 watcher.onRemove (tag) ->
                     utils.remove tags, tag
                 doc2u.parent = doc2div1
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2b, doc2u, doc2u2], maxDeep: 1
-                    doc2u.parent = null
-                    whenChange tags, ->
-                        assert.isEqual tags, [doc2b], maxDeep: 1
-                        done()
+                assert.isEqual tags, [doc2b, doc2u, doc2u2], maxDeep: 1
+                doc2u.parent = null
+                assert.isEqual tags, [doc2b], maxDeep: 1
 
-            it '*[foo]', (done) ->
+            it '*[foo]', ->
                 watcher = doc2div1.watch '*[attr2]'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 watcher.onRemove (tag) ->
                     utils.remove tags, tag
                 doc2u.props.set 'attr2', '2'
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2u], maxDeep: 1
-                    doc2u.props.set 'attr2', undefined
-                    whenChange tags, ->
-                        assert.isEqual tags, []
-                        done()
+                assert.isEqual tags, [doc2u], maxDeep: 1
+                doc2u.props.set 'attr2', undefined
+                assert.isEqual tags, []
 
-            it 'E > * > F[foo]', (done) ->
+            it 'E > * > F[foo]', ->
                 doc2u.parent = null
                 watcher = doc2.watch 'div > * > u[color]'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 watcher.onRemove (tag) ->
                     utils.remove tags, tag
                 doc2u.parent = doc2b
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2u], maxDeep: 1
-                    doc2u.parent = null
-                    whenChange tags, ->
-                        assert.isEqual tags, []
-                        done()
+                assert.isEqual tags, [doc2u], maxDeep: 1
+                doc2u.parent = null
+                assert.isEqual tags, []
 
-            it 'E > * > F[foo], F[foo]', (done) ->
+            it 'E > * > F[foo], F[foo]', ->
                 doc2div1.parent = null
                 doc2div2.parent = null
                 watcher = doc2.watch 'div > * > u[color], div[attr]'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 watcher.onRemove (tag) ->
                     utils.remove tags, tag
                 doc2div1.parent = doc2
                 doc2div2.parent = doc2
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2u, doc2div2], maxDeep: 1
-                    doc2div1.parent = null
-                    doc2div2.parent = null
-                    whenChange tags, ->
-                        assert.isEqual tags, []
-                        done()
+                assert.isEqual tags, [doc2u, doc2div2], maxDeep: 1
+                doc2div1.parent = null
+                doc2div2.parent = null
+                assert.isEqual tags, []
 
-            it '&[foo]', (done) ->
-                doc2u.parent = null
+            it '&[foo]', ->
                 watcher = doc2u.watch '&[color]'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 watcher.onRemove (tag) ->
                     utils.remove tags, tag
-                doc2u.parent = doc2b
-                whenChange tags, ->
-                    assert.isEqual tags, [doc2u], maxDeep: 1
-                    doc2u.props.set 'color', undefined
-                    whenChange tags, ->
-                        assert.isEqual tags, []
-                        done()
+                assert.isEqual tags, [doc2u], maxDeep: 1
+                doc2u.props.set 'color', undefined
+                assert.isEqual tags, []
 
-            it '#text', (done) ->
+            it '#text', ->
                 watcher = doc2.watch '#text'
+                tags.push watcher.nodes...
                 watcher.onAdd (tag) ->
                     tags.push tag
                 watcher.onRemove (tag) ->
                     utils.remove tags, tag
-                whenChange tags, ->
                     assert.isEqual tags, [doc2em1.children[0]], maxDeep: 1
                     newText = new Element.Text
                     newText.parent = doc2em2
-                    whenChange tags, ->
-                        assert.isEqual tags, [doc2em1.children[0], newText], maxDeep: 1
-                        done()
+                    assert.isEqual tags, [doc2em1.children[0], newText], maxDeep: 1
 
-        it 'supports disconnect() in onRemove()', (done) ->
+        it 'supports disconnect() in onRemove()', ->
             tags = []
             removedTags = []
             doc2 = Element.fromHTML """
@@ -543,11 +514,8 @@ describe 'Document Element', ->
                     watcher2.disconnect()
             watcher2.onRemove (tag) ->
                 removedTags.push tag
-            whenChange tags, ->
-                b1.parent = null
-                whenChange removedTags, ->
-                    assert.isEqual removedTags, [b1, b2], maxDeep: 1
-                    done()
+            b1.parent = null
+            assert.isEqual removedTags, [b1, b2], maxDeep: 1
 
     it 'visible property is editable', ->
         assert.ok p.visible

--- a/tests/integration/src/eventLoop/index.coffee
+++ b/tests/integration/src/eventLoop/index.coffee
@@ -1,0 +1,25 @@
+eventLoop = require 'src/eventLoop'
+
+describe 'src/eventLoop', ->
+    it 'calls setImmediate callback when all locks will be released', ->
+        called = false
+        callback = -> called = true
+        eventLoop.lock()
+
+        eventLoop.setImmediate callback
+        assert.notOk called
+
+        eventLoop.lock()
+        assert.notOk called
+
+        eventLoop.release()
+        assert.notOk called
+
+        eventLoop.release()
+        assert.ok called
+
+    it 'calls setImmediate callback when loop is not locked', ->
+        called = false
+        callback = -> called = true
+        eventLoop.setImmediate callback
+        assert.ok called

--- a/tests/unit/src/renderer/flow.coffee
+++ b/tests/unit/src/renderer/flow.coffee
@@ -19,77 +19,54 @@ expectSize = (item, width, height) ->
     item
 
 describe 'renderer Flow', ->
-    flow = items = item1 = item2 = item3 = onReady = null
+    flow = items = item1 = item2 = item3 = null
 
     beforeEach ->
-        onReadyCallback = null
-        onReadyCalled = false
-        onReady = ->
-            if onReadyCalled or not listen
-                return
-            onReadyCalled = true
-            setTimeout onReadyCallback
-
         comp = new Renderer.Component
         flow = Flow.New comp
-        flow.onWidthChange onReady
-        flow.onHeightChange onReady
-        flow.onMarginChange onReady
 
         items = []
         for i in [0...3]
             item = items[i] = Item.New comp
             item.parent = flow
-            item.onXChange onReady
-            item.onYChange onReady
-            item.onWidthChange onReady
-            item.onHeightChange onReady
         [item1, item2, item3] = items
 
-        listen = false
-        onReady = (callback) ->
-            listen = true
-            onReadyCallback = callback
-
-    it '1', (done) ->
+    it '1', ->
         flow.collapseMargins = true
         setSize item1, 50, 50
         setSize item2, 50, 50
         setSize item3, 50, 50
-        onReady ->
-            expectSize flow, 150, 50
-            expectPosition item1, 0, 0
-            expectPosition item2, 50, 0
-            expectPosition item3, 100, 0
-            done()
 
-    it '2', (done) ->
+        expectSize flow, 150, 50
+        expectPosition item1, 0, 0
+        expectPosition item2, 50, 0
+        expectPosition item3, 100, 0
+
+    it '2', ->
         flow.width = 100
         flow.collapseMargins = true
         setSize item1, 50, 50
         setSize item2, 50, 50
         setSize item3, 50, 50
-        onReady ->
-            expectSize flow, 100, 100
-            expectPosition item1, 0, 0
-            expectPosition item2, 50, 0
-            expectPosition item3, 0, 50
-            done()
 
-    it '3', (done) ->
+        expectSize flow, 100, 100
+        expectPosition item1, 0, 0
+        expectPosition item2, 50, 0
+        expectPosition item3, 0, 50
+
+    it '3', ->
         flow.height = 20
         flow.collapseMargins = true
         setSize item1, 50, 50
         setSize item2, 50, 50
         setSize item3, 50, 50
-        onReady ->
-            expectSize flow, 150, 20
-            expectPosition item1, 0, 0
-            expectPosition item2, 50, 0
-            expectPosition item3, 100, 0
-            done()
 
-    it '4', (done) ->
+        expectSize flow, 150, 20
+        expectPosition item1, 0, 0
+        expectPosition item2, 50, 0
+        expectPosition item3, 100, 0
+
+    it '4', ->
         flow.width = 120
         flow.collapseMargins = true
         setSize item1, 50, 50
@@ -97,14 +74,13 @@ describe 'renderer Flow', ->
         setSize item2, 50, 50
         setSize item3, 50, 50
         item3.margin = 20
-        onReady ->
-            expectSize flow, 120, 120
-            expectPosition item1, 0, 0
-            expectPosition item2, 70, 0
-            expectPosition item3, 0, 70
-            done()
 
-    it '5', (done) ->
+        expectSize flow, 120, 120
+        expectPosition item1, 0, 0
+        expectPosition item2, 70, 0
+        expectPosition item3, 0, 70
+
+    it '5', ->
         flow.width = 140
         flow.collapseMargins = true
         flow.includeBorderMargins = true
@@ -113,14 +89,13 @@ describe 'renderer Flow', ->
         setSize item2, 50, 50
         setSize item3, 50, 50
         item3.margin = 20
-        onReady ->
-            expectSize flow, 140, 150
-            expectPosition item1, 20, 10
-            expectPosition item2, 90, 0
-            expectPosition item3, 20, 80
-            done()
 
-    it '6', (done) ->
+        expectSize flow, 140, 150
+        expectPosition item1, 20, 10
+        expectPosition item2, 90, 0
+        expectPosition item3, 20, 80
+
+    it '6', ->
         flow.collapseMargins = true
         flow.includeBorderMargins = true
         setSize item1, 50, 50
@@ -128,28 +103,26 @@ describe 'renderer Flow', ->
         setSize item2, 50, 50
         setSize item3, 50, 50
         item3.margin = 20
-        onReady ->
-            expectSize flow, 230, 90
-            expectPosition item1, 20, 10
-            expectPosition item2, 90, 0
-            expectPosition item3, 160, 20
-            done()
 
-    it '7', (done) ->
+        expectSize flow, 230, 90
+        expectPosition item1, 20, 10
+        expectPosition item2, 90, 0
+        expectPosition item3, 160, 20
+
+    it '7', ->
         flow.width = 120
         setSize item1, 50, 50
         item1.margin = '10 20'
         setSize item2, 50, 50
         setSize item3, 50, 50
         item3.margin = 20
-        onReady ->
-            expectSize flow, 120, 130
-            expectPosition item1, 0, 0
-            expectPosition item2, 70, 0
-            expectPosition item3, 0, 80
-            done()
 
-    it '8', (done) ->
+        expectSize flow, 120, 130
+        expectPosition item1, 0, 0
+        expectPosition item2, 70, 0
+        expectPosition item3, 0, 80
+
+    it '8', ->
         flow.width = 160
         flow.includeBorderMargins = true
         setSize item1, 50, 50
@@ -157,29 +130,27 @@ describe 'renderer Flow', ->
         setSize item2, 50, 50
         setSize item3, 50, 50
         item3.margin = 20
-        onReady ->
-            expectSize flow, 160, 160
-            expectPosition item1, 20, 10
-            expectPosition item2, 90, 0
-            expectPosition item3, 20, 90
-            done()
 
-    it '9', (done) ->
+        expectSize flow, 160, 160
+        expectPosition item1, 20, 10
+        expectPosition item2, 90, 0
+        expectPosition item3, 20, 90
+
+    it '9', ->
         flow.width = 100
         flow.collapseMargins = true
         setSize item1, 50, 50
         setSize item2, 0, 50
         item2.layout.fillWidth = true
         setSize item3, 50, 50
-        onReady ->
-            expectSize flow, 100, 150
-            expectPosition item1, 0, 0
-            expectPosition item2, 0, 50
-            expectSize item2, 100, 50
-            expectPosition item3, 0, 100
-            done()
 
-    it '10', (done) ->
+        expectSize flow, 100, 150
+        expectPosition item1, 0, 0
+        expectPosition item2, 0, 50
+        expectSize item2, 100, 50
+        expectPosition item3, 0, 100
+
+    it '10', ->
         flow.width = 100
         flow.collapseMargins = true
         setSize item1, 50, 50
@@ -187,15 +158,14 @@ describe 'renderer Flow', ->
         item2.layout.fillWidth = true
         item2.margin = 10
         setSize item3, 50, 50
-        onReady ->
-            expectSize flow, 100, 170
-            expectPosition item1, 0, 0
-            expectPosition item2, 0, 60
-            expectSize item2, 100, 50
-            expectPosition item3, 0, 120
-            done()
 
-    it '11', (done) ->
+        expectSize flow, 100, 170
+        expectPosition item1, 0, 0
+        expectPosition item2, 0, 60
+        expectSize item2, 100, 50
+        expectPosition item3, 0, 120
+
+    it '11', ->
         flow.width = 100
         flow.collapseMargins = true
         flow.includeBorderMargins = true
@@ -204,15 +174,14 @@ describe 'renderer Flow', ->
         item2.layout.fillWidth = true
         item2.margin = 10
         setSize item3, 50, 50
-        onReady ->
-            expectSize flow, 100, 170
-            expectPosition item1, 0, 0
-            expectPosition item2, 10, 60
-            expectSize item2, 80, 50
-            expectPosition item3, 0, 120
-            done()
 
-    it '12', (done) ->
+        expectSize flow, 100, 170
+        expectPosition item1, 0, 0
+        expectPosition item2, 10, 60
+        expectSize item2, 80, 50
+        expectPosition item3, 0, 120
+
+    it '12', ->
         flow.width = 110
         flow.height = 200
         flow.collapseMargins = true
@@ -221,10 +190,9 @@ describe 'renderer Flow', ->
         item2.layout.fillHeight = true
         item2.margin = 10
         setSize item3, 50, 50
-        onReady ->
-            expectSize flow, 110, 200
-            expectPosition item1, 0, 0
-            expectPosition item2, 60, 0
-            expectSize item2, 50, 140
-            expectPosition item3, 0, 150
-            done()
+
+        expectSize flow, 110, 200
+        expectPosition item1, 0, 0
+        expectPosition item2, 60, 0
+        expectSize item2, 50, 140
+        expectPosition item3, 0, 150

--- a/tests/visual/utils.client.coffee
+++ b/tests/visual/utils.client.coffee
@@ -7,8 +7,8 @@ exports.Checker = class Checker
         @prefix = "tests/visual/#{prefix}"
     test: (name) ->
         item = @styles[name]()
-        item.parent = Neft.Renderer.window
         item.layout.enabled = false
+        item.parent = Neft.Renderer.window
         expected = "#{@prefix}/#{name}.png"
         takeScreenshot expected, ->
             item.parent = null


### PR DESCRIPTION
`signal.setImmediate` has been moved to the new `eventLoop` module.

More places right now locks the event loop.

All updates on native devices now should be much smoother with no extra frame for layout between changes.